### PR TITLE
Redis reconnect fix

### DIFF
--- a/process/eventsHandler.go
+++ b/process/eventsHandler.go
@@ -166,11 +166,6 @@ func (eh *eventsHandler) tryCheckProcessedWithRetry(blockHash string) bool {
 		}
 	}
 
-	if err != nil {
-		log.Error("failed to check event in locker", "error", err.Error())
-		return false
-	}
-
 	if !setSuccessful {
 		log.Debug("did not succeed to set event in locker")
 		return false

--- a/process/eventsHandler_test.go
+++ b/process/eventsHandler_test.go
@@ -289,26 +289,6 @@ func TestTryCheckProcessedWithRetry(t *testing.T) {
 		assert.True(t, ok)
 	})
 
-	t.Run("locker service is failing on first try, but has connection", func(t *testing.T) {
-		t.Parallel()
-
-		args := createMockEventsHandlerArgs()
-		args.Locker = &mocks.LockerStub{
-			IsEventProcessedCalled: func(ctx context.Context, blockHash string) (bool, error) {
-				return false, errors.New("fail to process")
-			},
-			HasConnectionCalled: func(ctx context.Context) bool {
-				return true
-			},
-		}
-
-		eventsHandler, err := process.NewEventsHandler(args)
-		require.Nil(t, err)
-
-		ok := eventsHandler.TryCheckProcessedWithRetry(hash)
-		assert.False(t, ok)
-	})
-
 	t.Run("locker service is failing on first try, has no connection, works on second try", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
- Handle edge case when notifier will remain connected to sentinel, but redis nodes are not responding anymore.
- Retry until locker set event is successful. (to make sure no event is lost)