### PR TITLE
Publish txs and scrs to rabbitmq

### DIFF
--- a/api/groups/eventsGroup.go
+++ b/api/groups/eventsGroup.go
@@ -15,6 +15,7 @@ const (
 	pushEventsEndpoint      = "/push"
 	revertEventsEndpoint    = "/revert"
 	finalizedEventsEndpoint = "/finalized"
+	txsEventsEndpoint       = "/txs"
 )
 
 type eventsGroup struct {
@@ -52,6 +53,11 @@ func NewEventsGroup(facade EventsFacadeHandler) (*eventsGroup, error) {
 			Method:  http.MethodPost,
 			Path:    finalizedEventsEndpoint,
 			Handler: h.finalizedEvents,
+		},
+		{
+			Method:  http.MethodPost,
+			Path:    txsEventsEndpoint,
+			Handler: h.txsEvents,
 		},
 	}
 
@@ -103,6 +109,20 @@ func (h *eventsGroup) finalizedEvents(c *gin.Context) {
 	}
 
 	h.facade.HandleFinalizedEvents(finalizedBlock)
+
+	shared.JSONResponse(c, http.StatusOK, nil, "")
+}
+
+func (h *eventsGroup) txsEvents(c *gin.Context) {
+	var blockTxs data.BlockTxs
+
+	err := c.Bind(&blockTxs)
+	if err != nil {
+		shared.JSONResponse(c, http.StatusBadRequest, nil, err.Error())
+		return
+	}
+
+	h.facade.HandleTxsEvents(blockTxs)
 
 	shared.JSONResponse(c, http.StatusOK, nil, "")
 }

--- a/api/groups/eventsGroup.go
+++ b/api/groups/eventsGroup.go
@@ -74,10 +74,6 @@ func (h *eventsGroup) pushEvents(c *gin.Context) {
 		return
 	}
 
-	log.Debug("blockEvents", "hash", blockEvents.Hash)
-	log.Debug("blockEvents", "logs", blockEvents.LogEvents)
-	log.Debug("blockEvents", "txs", blockEvents.Txs)
-
 	h.facade.HandlePushEvents(blockEvents)
 
 	shared.JSONResponse(c, http.StatusOK, nil, "")

--- a/api/groups/eventsGroup_test.go
+++ b/api/groups/eventsGroup_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	apiErrors "github.com/ElrondNetwork/notifier-go/api/errors"
 	"github.com/ElrondNetwork/notifier-go/api/groups"
 	"github.com/ElrondNetwork/notifier-go/data"
@@ -81,6 +83,16 @@ func TestEventsGroup_PushEvents(t *testing.T) {
 
 		blockEvents := data.SaveBlockData{
 			Hash: "hash1",
+			Txs: map[string]transaction.Transaction{
+				"hash2": {
+					Nonce: 2,
+				},
+			},
+			Scrs: map[string]smartContractResult.SmartContractResult{
+				"hash3": {
+					Nonce: 3,
+				},
+			},
 			LogEvents: []data.Event{
 				{
 					Address: "addr1",

--- a/api/groups/eventsGroup_test.go
+++ b/api/groups/eventsGroup_test.go
@@ -79,9 +79,9 @@ func TestEventsGroup_PushEvents(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		blockEvents := data.BlockEvents{
+		blockEvents := data.SaveBlockData{
 			Hash: "hash1",
-			Events: []data.Event{
+			LogEvents: []data.Event{
 				{
 					Address: "addr1",
 				},
@@ -91,7 +91,7 @@ func TestEventsGroup_PushEvents(t *testing.T) {
 
 		wasCalled := false
 		facade := &mocks.FacadeStub{
-			HandlePushEventsCalled: func(events data.BlockEvents) {
+			HandlePushEventsCalled: func(events data.SaveBlockData) {
 				wasCalled = true
 				assert.Equal(t, blockEvents, events)
 			},

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -8,10 +8,9 @@ import (
 
 // EventsFacadeHandler defines the behavior of a facade handler needed for events group
 type EventsFacadeHandler interface {
-	HandlePushEvents(events data.BlockEvents)
+	HandlePushEvents(events data.SaveBlockData)
 	HandleRevertEvents(revertBlock data.RevertBlock)
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
-	HandleTxsEvents(blockTxs data.BlockTxs)
 	GetConnectorUserAndPass() (string, string)
 	IsInterfaceNil() bool
 }

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -11,6 +11,7 @@ type EventsFacadeHandler interface {
 	HandlePushEvents(events data.BlockEvents)
 	HandleRevertEvents(revertBlock data.RevertBlock)
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
+	HandleTxsEvents(blockTxs data.BlockTxs)
 	GetConnectorUserAndPass() (string, string)
 	IsInterfaceNil() bool
 }

--- a/api/shared/interface.go
+++ b/api/shared/interface.go
@@ -23,10 +23,9 @@ type GroupHandler interface {
 
 // FacadeHandler defines the behavior of a notifier base facade handler
 type FacadeHandler interface {
-	HandlePushEvents(events data.BlockEvents)
+	HandlePushEvents(events data.SaveBlockData)
 	HandleRevertEvents(revertBlock data.RevertBlock)
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
-	HandleTxsEvents(blockTxs data.BlockTxs)
 	GetConnectorUserAndPass() (string, string)
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
 	IsInterfaceNil() bool

--- a/api/shared/interface.go
+++ b/api/shared/interface.go
@@ -26,6 +26,7 @@ type FacadeHandler interface {
 	HandlePushEvents(events data.BlockEvents)
 	HandleRevertEvents(revertBlock data.RevertBlock)
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
+	HandleTxsEvents(blockTxs data.BlockTxs)
 	GetConnectorUserAndPass() (string, string)
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
 	IsInterfaceNil() bool

--- a/cmd/notifier/config/config.toml
+++ b/cmd/notifier/config/config.toml
@@ -48,3 +48,7 @@
     # The exchange name which holds finalized block events
     # Expected type: fanout
     FinalizedEventsExchange = "finalized_events"
+
+    # The exchange name which holds block txs events
+    # Expected type: fanout
+    TxsEventsExchange = "txs_events"

--- a/cmd/notifier/config/config.toml
+++ b/cmd/notifier/config/config.toml
@@ -52,3 +52,7 @@
     # The exchange name which holds block txs events
     # Expected type: fanout
     TxsEventsExchange = "txs_events"
+
+    # The exchange name which holds block scrs events
+    # Expected type: fanout
+    ScrsEventsExchange = "scrs_events"

--- a/cmd/notifier/config/config.toml
+++ b/cmd/notifier/config/config.toml
@@ -51,8 +51,8 @@
 
     # The exchange name which holds block txs events
     # Expected type: fanout
-    TxsEventsExchange = "txs_events"
+    BlockTxsExchange = "block_txs"
 
     # The exchange name which holds block scrs events
     # Expected type: fanout
-    ScrsEventsExchange = "scrs_events"
+    BlockScrsExchange = "block_scrs"

--- a/common/constants.go
+++ b/common/constants.go
@@ -28,4 +28,10 @@ const (
 
 	// FinalizedBlockEvents defines the subscription event type for finalized blocks
 	FinalizedBlockEvents string = "finalized_events"
+
+	// BlockTxsEvents defines the subscription event type for block txs
+	BlockTxsEvents string = "txs_events"
+
+	// BlockScrsEvents defines the subscription event type for block scrs
+	BlockScrsEvents string = "scrs_events"
 )

--- a/common/constants.go
+++ b/common/constants.go
@@ -29,9 +29,9 @@ const (
 	// FinalizedBlockEvents defines the subscription event type for finalized blocks
 	FinalizedBlockEvents string = "finalized_events"
 
-	// BlockTxsEvents defines the subscription event type for block txs
-	BlockTxsEvents string = "txs_events"
+	// BlockTxs defines the subscription event type for block txs
+	BlockTxs string = "block_txs"
 
-	// BlockScrsEvents defines the subscription event type for block scrs
-	BlockScrsEvents string = "scrs_events"
+	// BlockScrs defines the subscription event type for block scrs
+	BlockScrs string = "block_scrs"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -33,8 +33,8 @@ type RabbitMQConfig struct {
 	EventsExchange          string
 	RevertEventsExchange    string
 	FinalizedEventsExchange string
-	TxsEventsExchange       string
-	ScrsEventsExchange      string
+	BlockTxsExchange        string
+	BlockScrsExchange       string
 }
 
 // FlagsConfig holds the values for CLI flags

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type RabbitMQConfig struct {
 	EventsExchange          string
 	RevertEventsExchange    string
 	FinalizedEventsExchange string
+	TxsEventsExchange       string
 }
 
 // FlagsConfig holds the values for CLI flags

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type RabbitMQConfig struct {
 	RevertEventsExchange    string
 	FinalizedEventsExchange string
 	TxsEventsExchange       string
+	ScrsEventsExchange      string
 }
 
 // FlagsConfig holds the values for CLI flags

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -3,6 +3,7 @@ package data
 import (
 	"encoding/json"
 
+	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 )
 
@@ -48,4 +49,11 @@ type FinalizedBlock struct {
 type BlockTxs struct {
 	Hash string                             `json:"hash"`
 	Txs  map[string]transaction.Transaction `json:"txs"`
+}
+
+type SaveBlockData struct {
+	Hash      string                                             `json:"hash"`
+	Txs       map[string]transaction.Transaction                 `json:"txs"`
+	Scrs      map[string]smartContractResult.SmartContractResult `json:"scrs"`
+	LogEvents []Event                                            `json:"events"`
 }

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -51,6 +51,11 @@ type BlockTxs struct {
 	Txs  map[string]transaction.Transaction `json:"txs"`
 }
 
+type BlockScrs struct {
+	Hash string                                             `json:"hash"`
+	Scrs map[string]smartContractResult.SmartContractResult `json:"scrs"`
+}
+
 type SaveBlockData struct {
 	Hash      string                                             `json:"hash"`
 	Txs       map[string]transaction.Transaction                 `json:"txs"`

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -3,7 +3,7 @@ package data
 import (
 	"encoding/json"
 
-	"github.com/ElrondNetwork/elrond-go-core/data"
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 )
 
 // WSEvent defines a websocket event
@@ -47,5 +47,5 @@ type FinalizedBlock struct {
 
 type BlockTxs struct {
 	Hash string                             `json:"hash"`
-	Txs  map[string]data.TransactionHandler `json:"txs"`
+	Txs  map[string]transaction.Transaction `json:"txs"`
 }

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -46,16 +46,19 @@ type FinalizedBlock struct {
 	Hash string `json:"hash"`
 }
 
+// BlockTxs holds the block transactions
 type BlockTxs struct {
 	Hash string                             `json:"hash"`
 	Txs  map[string]transaction.Transaction `json:"txs"`
 }
 
+// BlockScrs holds the block smart contract results
 type BlockScrs struct {
 	Hash string                                             `json:"hash"`
 	Scrs map[string]smartContractResult.SmartContractResult `json:"scrs"`
 }
 
+// SaveBlockData holds the block data that will be received on push events
 type SaveBlockData struct {
 	Hash      string                                             `json:"hash"`
 	Txs       map[string]transaction.Transaction                 `json:"txs"`

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -1,6 +1,10 @@
 package data
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/ElrondNetwork/elrond-go-core/data"
+)
 
 // WSEvent defines a websocket event
 type WSEvent struct {
@@ -39,4 +43,9 @@ type RevertBlock struct {
 // FinalizedBlock holds finalized block data
 type FinalizedBlock struct {
 	Hash string `json:"hash"`
+}
+
+type BlockTxs struct {
+	Hash string                             `json:"hash"`
+	Txs  map[string]data.TransactionHandler `json:"txs"`
 }

--- a/disabled/disabledHub.go
+++ b/disabled/disabledHub.go
@@ -25,6 +25,10 @@ func (h *Hub) BroadcastRevert(_ data.RevertBlock) {
 func (h *Hub) BroadcastFinalized(_ data.FinalizedBlock) {
 }
 
+// BroadcastTxs does nothing
+func (h *Hub) BroadcastTxs(_ data.BlockTxs) {
+}
+
 // RegisterEvent does nothing
 func (h *Hub) RegisterEvent(_ dispatcher.EventDispatcher) {
 }

--- a/disabled/disabledHub.go
+++ b/disabled/disabledHub.go
@@ -29,6 +29,10 @@ func (h *Hub) BroadcastFinalized(_ data.FinalizedBlock) {
 func (h *Hub) BroadcastTxs(_ data.BlockTxs) {
 }
 
+// BroadcastScrs does nothing
+func (h *Hub) BroadcastScrs(_ data.BlockScrs) {
+}
+
 // RegisterEvent does nothing
 func (h *Hub) RegisterEvent(_ dispatcher.EventDispatcher) {
 }

--- a/disabled/disabledPublisher.go
+++ b/disabled/disabledPublisher.go
@@ -23,6 +23,10 @@ func (dp *Publisher) BroadcastRevert(_ data.RevertBlock) {
 func (dp *Publisher) BroadcastFinalized(_ data.FinalizedBlock) {
 }
 
+// BroadcastTxs does nothing
+func (dp *Publisher) BroadcastTxs(_ data.BlockTxs) {
+}
+
 // Close returns nil
 func (dp *Publisher) Close() error {
 	return nil

--- a/disabled/disabledPublisher.go
+++ b/disabled/disabledPublisher.go
@@ -27,6 +27,10 @@ func (dp *Publisher) BroadcastFinalized(_ data.FinalizedBlock) {
 func (dp *Publisher) BroadcastTxs(_ data.BlockTxs) {
 }
 
+// BroadcastScrs does nothing
+func (dp *Publisher) BroadcastScrs(_ data.BlockScrs) {
+}
+
 // Close returns nil
 func (dp *Publisher) Close() error {
 	return nil

--- a/dispatcher/hub/commonHub.go
+++ b/dispatcher/hub/commonHub.go
@@ -31,6 +31,7 @@ type commonHub struct {
 	broadcast          chan data.BlockEvents
 	broadcastRevert    chan data.RevertBlock
 	broadcastFinalized chan data.FinalizedBlock
+	broadcastTxs       chan data.BlockTxs
 	closeChan          chan struct{}
 	cancelFunc         func()
 }
@@ -52,6 +53,7 @@ func NewCommonHub(args ArgsCommonHub) (*commonHub, error) {
 		broadcast:          make(chan data.BlockEvents),
 		broadcastRevert:    make(chan data.RevertBlock),
 		broadcastFinalized: make(chan data.FinalizedBlock),
+		broadcastTxs:       make(chan data.BlockTxs),
 		closeChan:          make(chan struct{}),
 	}, nil
 }
@@ -128,6 +130,15 @@ func (ch *commonHub) BroadcastRevert(event data.RevertBlock) {
 func (ch *commonHub) BroadcastFinalized(event data.FinalizedBlock) {
 	select {
 	case ch.broadcastFinalized <- event:
+	case <-ch.closeChan:
+	}
+}
+
+// BroadcastTxs handles block txs event pushed by producers into the broadcast channel
+// Upon reading the channel, the hub notifies the registered dispatchers, if any
+func (ch *commonHub) BroadcastTxs(event data.BlockTxs) {
+	select {
+	case ch.broadcastTxs <- event:
 	case <-ch.closeChan:
 	}
 }

--- a/dispatcher/hub/commonHub.go
+++ b/dispatcher/hub/commonHub.go
@@ -32,6 +32,7 @@ type commonHub struct {
 	broadcastRevert    chan data.RevertBlock
 	broadcastFinalized chan data.FinalizedBlock
 	broadcastTxs       chan data.BlockTxs
+	broadcastScrs      chan data.BlockScrs
 	closeChan          chan struct{}
 	cancelFunc         func()
 }
@@ -54,6 +55,7 @@ func NewCommonHub(args ArgsCommonHub) (*commonHub, error) {
 		broadcastRevert:    make(chan data.RevertBlock),
 		broadcastFinalized: make(chan data.FinalizedBlock),
 		broadcastTxs:       make(chan data.BlockTxs),
+		broadcastScrs:      make(chan data.BlockScrs),
 		closeChan:          make(chan struct{}),
 	}, nil
 }
@@ -139,6 +141,15 @@ func (ch *commonHub) BroadcastFinalized(event data.FinalizedBlock) {
 func (ch *commonHub) BroadcastTxs(event data.BlockTxs) {
 	select {
 	case ch.broadcastTxs <- event:
+	case <-ch.closeChan:
+	}
+}
+
+// BroadcastScrs handles block scrs event pushed by producers into the broadcast channel
+// Upon reading the channel, the hub notifies the registered dispatchers, if any
+func (ch *commonHub) BroadcastScrs(event data.BlockScrs) {
+	select {
+	case ch.broadcastScrs <- event:
 	case <-ch.closeChan:
 	}
 }

--- a/dispatcher/hub/commonHub.go
+++ b/dispatcher/hub/commonHub.go
@@ -277,7 +277,7 @@ func (ch *commonHub) handleScrsBroadcast(blockScrs data.BlockScrs) {
 	dispatchersMap := make(map[uuid.UUID]data.BlockScrs)
 
 	for _, subscription := range subscriptions {
-		if subscription.EventType != common.BlockTxsEvents {
+		if subscription.EventType != common.BlockScrsEvents {
 			continue
 		}
 

--- a/dispatcher/hub/commonHub.go
+++ b/dispatcher/hub/commonHub.go
@@ -255,7 +255,7 @@ func (ch *commonHub) handleTxsBroadcast(blockTxs data.BlockTxs) {
 	dispatchersMap := make(map[uuid.UUID]data.BlockTxs)
 
 	for _, subscription := range subscriptions {
-		if subscription.EventType != common.BlockTxsEvents {
+		if subscription.EventType != common.BlockTxs {
 			continue
 		}
 
@@ -277,7 +277,7 @@ func (ch *commonHub) handleScrsBroadcast(blockScrs data.BlockScrs) {
 	dispatchersMap := make(map[uuid.UUID]data.BlockScrs)
 
 	for _, subscription := range subscriptions {
-		if subscription.EventType != common.BlockScrsEvents {
+		if subscription.EventType != common.BlockScrs {
 			continue
 		}
 

--- a/dispatcher/hub/commonHub_test.go
+++ b/dispatcher/hub/commonHub_test.go
@@ -275,7 +275,7 @@ func TestCommonHub_HandleTxsBroadcast(t *testing.T) {
 
 	args := createMockCommonHubArgs()
 	hub, err := NewCommonHub(args)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}
 	numCalls := uint32(0)

--- a/dispatcher/hub/commonHub_test.go
+++ b/dispatcher/hub/commonHub_test.go
@@ -65,16 +65,18 @@ func TestCommonHub_RegisterDispatcher(t *testing.T) {
 	require.Nil(t, err)
 
 	dispatcher1 := mocks.NewDispatcherMock(nil, hub)
-	//dispatcher2 := mocks.NewDispatcherMock(nil, hub)
+	dispatcher2 := mocks.NewDispatcherMock(nil, hub)
 
 	hub.Run()
 	defer hub.Close()
 
 	hub.RegisterEvent(dispatcher1)
-	require.True(t, hub.CheckDispatcherByID(dispatcher1.GetID(), dispatcher1))
+	hub.RegisterEvent(dispatcher2)
 
-	// hub.RegisterEvent(dispatcher2)
-	// require.True(t, hub.CheckDispatcherByID(dispatcher2.GetID(), dispatcher2))
+	time.Sleep(time.Millisecond * 100)
+
+	require.True(t, hub.CheckDispatcherByID(dispatcher1.GetID(), dispatcher1))
+	require.True(t, hub.CheckDispatcherByID(dispatcher2.GetID(), dispatcher2))
 }
 
 func TestCommonHub_UnregisterDispatcher(t *testing.T) {

--- a/dispatcher/hub/commonHub_test.go
+++ b/dispatcher/hub/commonHub_test.go
@@ -289,7 +289,7 @@ func TestCommonHub_HandleTxsBroadcast(t *testing.T) {
 	hub.Subscribe(data.SubscribeEvent{
 		SubscriptionEntries: []data.SubscriptionEntry{
 			{
-				EventType: common.BlockTxsEvents,
+				EventType: common.BlockTxs,
 			},
 		},
 	})
@@ -328,7 +328,7 @@ func TestCommonHub_HandleScrsBroadcast(t *testing.T) {
 	hub.Subscribe(data.SubscribeEvent{
 		SubscriptionEntries: []data.SubscriptionEntry{
 			{
-				EventType: common.BlockScrsEvents,
+				EventType: common.BlockScrs,
 			},
 		},
 	})

--- a/dispatcher/hub/commonHub_test.go
+++ b/dispatcher/hub/commonHub_test.go
@@ -1,7 +1,10 @@
 package hub
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ElrondNetwork/notifier-go/common"
 	"github.com/ElrondNetwork/notifier-go/data"
@@ -62,13 +65,16 @@ func TestCommonHub_RegisterDispatcher(t *testing.T) {
 	require.Nil(t, err)
 
 	dispatcher1 := mocks.NewDispatcherMock(nil, hub)
-	dispatcher2 := mocks.NewDispatcherMock(nil, hub)
+	//dispatcher2 := mocks.NewDispatcherMock(nil, hub)
 
-	hub.registerDispatcher(dispatcher1)
-	require.True(t, hub.dispatchers[dispatcher1.GetID()] == dispatcher1)
+	hub.Run()
+	defer hub.Close()
 
-	hub.registerDispatcher(dispatcher2)
-	require.True(t, hub.dispatchers[dispatcher2.GetID()] == dispatcher2)
+	hub.RegisterEvent(dispatcher1)
+	require.True(t, hub.CheckDispatcherByID(dispatcher1.GetID(), dispatcher1))
+
+	// hub.RegisterEvent(dispatcher2)
+	// require.True(t, hub.CheckDispatcherByID(dispatcher2.GetID(), dispatcher2))
 }
 
 func TestCommonHub_UnregisterDispatcher(t *testing.T) {
@@ -81,13 +87,18 @@ func TestCommonHub_UnregisterDispatcher(t *testing.T) {
 	dispatcher1 := mocks.NewDispatcherMock(nil, hub)
 	dispatcher2 := mocks.NewDispatcherMock(nil, hub)
 
-	hub.registerDispatcher(dispatcher1)
-	hub.registerDispatcher(dispatcher2)
+	hub.Run()
+	defer hub.Close()
 
-	hub.unregisterDispatcher(dispatcher1)
+	hub.RegisterEvent(dispatcher1)
+	hub.RegisterEvent(dispatcher2)
 
-	require.True(t, hub.dispatchers[dispatcher1.GetID()] == nil)
-	require.True(t, hub.dispatchers[dispatcher2.GetID()] == dispatcher2)
+	hub.UnregisterEvent(dispatcher1)
+
+	time.Sleep(time.Millisecond * 100)
+
+	require.True(t, hub.CheckDispatcherByID(dispatcher1.GetID(), nil))
+	require.True(t, hub.CheckDispatcherByID(dispatcher2.GetID(), dispatcher2))
 }
 
 func TestCommonHub_HandleBroadcastDispatcherReceivesEvents(t *testing.T) {
@@ -106,9 +117,14 @@ func TestCommonHub_HandleBroadcastDispatcherReceivesEvents(t *testing.T) {
 		SubscriptionEntries: []data.SubscriptionEntry{},
 	})
 
+	hub.Run()
+	defer hub.Close()
+
 	blockEvents := getEvents()
 
-	hub.handleBroadcast(blockEvents)
+	hub.Broadcast(blockEvents)
+
+	time.Sleep(time.Millisecond * 100)
 
 	require.True(t, consumer.HasEvents(blockEvents.Events))
 	require.True(t, len(consumer.CollectedEvents()) == len(blockEvents.Events))
@@ -126,8 +142,11 @@ func TestCommonHub_HandleBroadcastMultipleDispatchers(t *testing.T) {
 	consumer2 := mocks.NewConsumerMock()
 	dispatcher2 := mocks.NewDispatcherMock(consumer2, hub)
 
-	hub.registerDispatcher(dispatcher1)
-	hub.registerDispatcher(dispatcher2)
+	hub.Run()
+	defer hub.Close()
+
+	hub.RegisterEvent(dispatcher1)
+	hub.RegisterEvent(dispatcher2)
 
 	hub.Subscribe(data.SubscribeEvent{
 		DispatcherID: dispatcher1.GetID(),
@@ -150,7 +169,9 @@ func TestCommonHub_HandleBroadcastMultipleDispatchers(t *testing.T) {
 
 	blockEvents := getEvents()
 
-	hub.handleBroadcast(blockEvents)
+	hub.Broadcast(blockEvents)
+
+	time.Sleep(time.Millisecond * 100)
 
 	require.True(t, consumer1.HasEvent(blockEvents.Events[0]))
 	require.True(t, consumer2.HasEvent(blockEvents.Events[1]))
@@ -175,10 +196,12 @@ func TestCommonHub_HandleRevertBroadcast(t *testing.T) {
 	hub, err := NewCommonHub(args)
 	require.Nil(t, err)
 
-	wasCalled := false
+	wg := sync.WaitGroup{}
+	numCalls := uint32(0)
 	hub.registerDispatcher(&mocks.DispatcherStub{
 		RevertEventCalled: func(event data.RevertBlock) {
-			wasCalled = true
+			atomic.AddUint32(&numCalls, 1)
+			wg.Done()
 		},
 	})
 
@@ -190,14 +213,20 @@ func TestCommonHub_HandleRevertBroadcast(t *testing.T) {
 		},
 	})
 
+	hub.Run()
+	defer hub.Close()
+	wg.Add(1)
+
 	blockEvents := data.RevertBlock{
 		Hash:  "hash1",
 		Nonce: 1,
 	}
 
-	hub.handleRevertBroadcast(blockEvents)
+	hub.BroadcastRevert(blockEvents)
 
-	assert.True(t, wasCalled)
+	wg.Wait()
+
+	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
 }
 
 func TestCommonHub_HandleFinalizedBroadcast(t *testing.T) {
@@ -207,10 +236,12 @@ func TestCommonHub_HandleFinalizedBroadcast(t *testing.T) {
 	hub, err := NewCommonHub(args)
 	require.Nil(t, err)
 
-	wasCalled := false
+	wg := sync.WaitGroup{}
+	numCalls := uint32(0)
 	hub.registerDispatcher(&mocks.DispatcherStub{
 		FinalizedEventCalled: func(event data.FinalizedBlock) {
-			wasCalled = true
+			atomic.AddUint32(&numCalls, 1)
+			wg.Done()
 		},
 	})
 
@@ -222,13 +253,97 @@ func TestCommonHub_HandleFinalizedBroadcast(t *testing.T) {
 		},
 	})
 
+	hub.Run()
+	defer hub.Close()
+	wg.Add(1)
+
 	blockEvents := data.FinalizedBlock{
 		Hash: "hash1",
 	}
 
-	hub.handleFinalizedBroadcast(blockEvents)
+	hub.BroadcastFinalized(blockEvents)
 
-	assert.True(t, wasCalled)
+	wg.Wait()
+
+	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+}
+
+func TestCommonHub_HandleTxsBroadcast(t *testing.T) {
+	t.Parallel()
+
+	args := createMockCommonHubArgs()
+	hub, err := NewCommonHub(args)
+	require.Nil(t, err)
+
+	wg := sync.WaitGroup{}
+	numCalls := uint32(0)
+	hub.registerDispatcher(&mocks.DispatcherStub{
+		TxsEventCalled: func(event data.BlockTxs) {
+			atomic.AddUint32(&numCalls, 1)
+			wg.Done()
+		},
+	})
+
+	hub.Subscribe(data.SubscribeEvent{
+		SubscriptionEntries: []data.SubscriptionEntry{
+			{
+				EventType: common.BlockTxsEvents,
+			},
+		},
+	})
+
+	hub.Run()
+	defer hub.Close()
+	wg.Add(1)
+
+	blockEvents := data.BlockTxs{
+		Hash: "hash1",
+	}
+
+	hub.BroadcastTxs(blockEvents)
+
+	wg.Wait()
+
+	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+}
+
+func TestCommonHub_HandleScrsBroadcast(t *testing.T) {
+	t.Parallel()
+
+	args := createMockCommonHubArgs()
+	hub, err := NewCommonHub(args)
+	require.Nil(t, err)
+
+	wg := sync.WaitGroup{}
+	numCalls := uint32(0)
+	hub.registerDispatcher(&mocks.DispatcherStub{
+		ScrsEventCalled: func(event data.BlockScrs) {
+			atomic.AddUint32(&numCalls, 1)
+			wg.Done()
+		},
+	})
+
+	hub.Subscribe(data.SubscribeEvent{
+		SubscriptionEntries: []data.SubscriptionEntry{
+			{
+				EventType: common.BlockScrsEvents,
+			},
+		},
+	})
+
+	hub.Run()
+	defer hub.Close()
+	wg.Add(1)
+
+	blockEvents := data.BlockScrs{
+		Hash: "hash1",
+	}
+
+	hub.BroadcastScrs(blockEvents)
+
+	wg.Wait()
+
+	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
 }
 
 func getEvents() data.BlockEvents {

--- a/dispatcher/hub/export_test.go
+++ b/dispatcher/hub/export_test.go
@@ -1,0 +1,13 @@
+package hub
+
+import (
+	"github.com/ElrondNetwork/notifier-go/dispatcher"
+	"github.com/google/uuid"
+)
+
+func (ch *commonHub) CheckDispatcherByID(uuid uuid.UUID, dispatcher dispatcher.EventDispatcher) bool {
+	ch.rwMut.Lock()
+	defer ch.rwMut.Unlock()
+
+	return ch.dispatchers[uuid] == dispatcher
+}

--- a/dispatcher/interface.go
+++ b/dispatcher/interface.go
@@ -25,6 +25,7 @@ type Hub interface {
 	BroadcastRevert(event data.RevertBlock)
 	BroadcastFinalized(event data.FinalizedBlock)
 	BroadcastTxs(event data.BlockTxs)
+	BroadcastScrs(event data.BlockScrs)
 	RegisterEvent(event EventDispatcher)
 	UnregisterEvent(event EventDispatcher)
 	Subscribe(event data.SubscribeEvent)

--- a/dispatcher/interface.go
+++ b/dispatcher/interface.go
@@ -15,6 +15,8 @@ type EventDispatcher interface {
 	PushEvents(events []data.Event)
 	RevertEvent(event data.RevertBlock)
 	FinalizedEvent(event data.FinalizedBlock)
+	TxsEvent(event data.BlockTxs)
+	ScrsEvent(event data.BlockScrs)
 }
 
 // Hub defines the behaviour of a hub component which should be able to register

--- a/dispatcher/interface.go
+++ b/dispatcher/interface.go
@@ -24,6 +24,7 @@ type Hub interface {
 	Broadcast(events data.BlockEvents)
 	BroadcastRevert(event data.RevertBlock)
 	BroadcastFinalized(event data.FinalizedBlock)
+	BroadcastTxs(event data.BlockTxs)
 	RegisterEvent(event EventDispatcher)
 	UnregisterEvent(event EventDispatcher)
 	Subscribe(event data.SubscribeEvent)

--- a/dispatcher/subscription.go
+++ b/dispatcher/subscription.go
@@ -140,7 +140,9 @@ func (sm *SubscriptionMapper) appendSubscription(sub data.Subscription) {
 
 func getEventType(subEntry data.SubscriptionEntry) string {
 	if subEntry.EventType == common.FinalizedBlockEvents ||
-		subEntry.EventType == common.RevertBlockEvents {
+		subEntry.EventType == common.RevertBlockEvents ||
+		subEntry.EventType == common.BlockTxsEvents ||
+		subEntry.EventType == common.BlockScrsEvents {
 		return subEntry.EventType
 	}
 

--- a/dispatcher/subscription.go
+++ b/dispatcher/subscription.go
@@ -141,8 +141,8 @@ func (sm *SubscriptionMapper) appendSubscription(sub data.Subscription) {
 func getEventType(subEntry data.SubscriptionEntry) string {
 	if subEntry.EventType == common.FinalizedBlockEvents ||
 		subEntry.EventType == common.RevertBlockEvents ||
-		subEntry.EventType == common.BlockTxsEvents ||
-		subEntry.EventType == common.BlockScrsEvents {
+		subEntry.EventType == common.BlockTxs ||
+		subEntry.EventType == common.BlockScrs {
 		return subEntry.EventType
 	}
 

--- a/dispatcher/ws/wsDispatcher.go
+++ b/dispatcher/ws/wsDispatcher.go
@@ -127,6 +127,46 @@ func (wd *websocketDispatcher) FinalizedEvent(event data.FinalizedBlock) {
 	wd.send <- wsEventBytes
 }
 
+// TxsEvent receives a block txs event and process it before pushing to socket
+func (wd *websocketDispatcher) TxsEvent(event data.BlockTxs) {
+	eventBytes, err := json.Marshal(event)
+	if err != nil {
+		log.Error("failure marshalling events", "err", err.Error())
+		return
+	}
+	wsEvent := &data.WSEvent{
+		Type: common.BlockTxsEvents,
+		Data: eventBytes,
+	}
+	wsEventBytes, err := json.Marshal(wsEvent)
+	if err != nil {
+		log.Error("failure marshalling events", "err", err.Error())
+		return
+	}
+
+	wd.send <- wsEventBytes
+}
+
+// ScrsEvent receives a block scrs event and process it before pushing to socket
+func (wd *websocketDispatcher) ScrsEvent(event data.BlockScrs) {
+	eventBytes, err := json.Marshal(event)
+	if err != nil {
+		log.Error("failure marshalling events", "err", err.Error())
+		return
+	}
+	wsEvent := &data.WSEvent{
+		Type: common.BlockScrsEvents,
+		Data: eventBytes,
+	}
+	wsEventBytes, err := json.Marshal(wsEvent)
+	if err != nil {
+		log.Error("failure marshalling events", "err", err.Error())
+		return
+	}
+
+	wd.send <- wsEventBytes
+}
+
 // writePump listens on the send-channel and pushes data on the socket stream
 func (wd *websocketDispatcher) writePump() {
 	ticker := time.NewTicker(pingPeriod)

--- a/dispatcher/ws/wsDispatcher.go
+++ b/dispatcher/ws/wsDispatcher.go
@@ -135,7 +135,7 @@ func (wd *websocketDispatcher) TxsEvent(event data.BlockTxs) {
 		return
 	}
 	wsEvent := &data.WSEvent{
-		Type: common.BlockTxsEvents,
+		Type: common.BlockTxs,
 		Data: eventBytes,
 	}
 	wsEventBytes, err := json.Marshal(wsEvent)
@@ -155,7 +155,7 @@ func (wd *websocketDispatcher) ScrsEvent(event data.BlockScrs) {
 		return
 	}
 	wsEvent := &data.WSEvent{
-		Type: common.BlockScrsEvents,
+		Type: common.BlockScrs,
 		Data: eventBytes,
 	}
 	wsEventBytes, err := json.Marshal(wsEvent)

--- a/eventNotifier.go
+++ b/eventNotifier.go
@@ -77,7 +77,12 @@ func (en *eventNotifier) SaveBlock(args *indexer.ArgsSaveBlockData) error {
 
 	log.Debug("checking if block has txs", "num txs", len(args.TransactionsPool.Txs))
 
-	blockTxs := data.BlockTxs{
+	type BlockTxs struct {
+		Hash string                                 `json:"hash"`
+		Txs  map[string]nodeData.TransactionHandler `json:"txs"`
+	}
+
+	blockTxs := BlockTxs{
 		Hash: headerHash,
 		Txs:  args.TransactionsPool.Txs,
 	}

--- a/eventNotifier.go
+++ b/eventNotifier.go
@@ -75,6 +75,8 @@ func (en *eventNotifier) SaveBlock(args *indexer.ArgsSaveBlockData) error {
 		return fmt.Errorf("%w in eventNotifier.SaveBlock while posting event data", err)
 	}
 
+	log.Debug("checking if block has txs", "num txs", len(args.TransactionsPool.Txs))
+
 	blockTxs := data.BlockTxs{
 		Hash: headerHash,
 		Txs:  args.TransactionsPool.Txs,

--- a/eventNotifier.go
+++ b/eventNotifier.go
@@ -21,7 +21,6 @@ const (
 	pushEventEndpoint       = "/events/push"
 	revertEventsEndpoint    = "/events/revert"
 	finalizedEventsEndpoint = "/events/finalized"
-	txsEventEndpoint        = "/events/txs"
 )
 
 type eventNotifier struct {
@@ -78,7 +77,7 @@ func (en *eventNotifier) SaveBlock(args *indexer.ArgsSaveBlockData) error {
 		LogEvents: events,
 	}
 
-	err := en.httpClient.Post(txsEventEndpoint, blockData, nil)
+	err := en.httpClient.Post(pushEventEndpoint, blockData, nil)
 	if err != nil {
 		return fmt.Errorf("%w in eventNotifier.SaveBlock while posting block data", err)
 	}

--- a/eventNotifier.go
+++ b/eventNotifier.go
@@ -125,9 +125,6 @@ func (en *eventNotifier) getLogEventsFromTransactionsPool(logs []*nodeData.LogDa
 	return events
 }
 
-// func (en *eventNotifier) getTxsFromTransactionsPool(txs map[string]nodeData.TransactionHandler) []data.Event {
-// }
-
 // RevertIndexedBlock converts revert data in order to be pushed to subscribers
 func (en *eventNotifier) RevertIndexedBlock(header nodeData.HeaderHandler, _ nodeData.BodyHandler) error {
 	blockHash, err := core.CalculateHash(en.marshalizer, en.hasher, header)

--- a/eventNotifier.go
+++ b/eventNotifier.go
@@ -23,6 +23,14 @@ const (
 	finalizedEventsEndpoint = "/events/finalized"
 )
 
+// SaveBlockData holds the data that will be sent to notifier instance
+type SaveBlockData struct {
+	Hash      string                                 `json:"hash"`
+	Txs       map[string]nodeData.TransactionHandler `json:"txs"`
+	Scrs      map[string]nodeData.TransactionHandler `json:"scrs"`
+	LogEvents []data.Event                           `json:"events"`
+}
+
 type eventNotifier struct {
 	isNilNotifier   bool
 	httpClient      client.HttpClient
@@ -62,13 +70,6 @@ func (en *eventNotifier) SaveBlock(args *indexer.ArgsSaveBlockData) error {
 
 	events := en.getLogEventsFromTransactionsPool(args.TransactionsPool.Logs)
 	log.Debug("extracted events from block logs", "num events", len(events))
-
-	type SaveBlockData struct {
-		Hash      string                                 `json:"hash"`
-		Txs       map[string]nodeData.TransactionHandler `json:"txs"`
-		Scrs      map[string]nodeData.TransactionHandler `json:"scrs"`
-		LogEvents []data.Event                           `json:"events"`
-	}
 
 	blockData := SaveBlockData{
 		Hash:      hex.EncodeToString(args.HeaderHash),

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -11,8 +11,8 @@ type EventsHandler interface {
 	HandlePushEvents(events data.BlockEvents)
 	HandleRevertEvents(revertBlock data.RevertBlock)
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
-	HandleTxsEvents(blockTxs data.BlockTxs)
-	HandleScrsEvents(blockScrs data.BlockScrs)
+	HandleBlockTxs(blockTxs data.BlockTxs)
+	HandleBlockScrs(blockScrs data.BlockScrs)
 	IsInterfaceNil() bool
 }
 

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -12,6 +12,7 @@ type EventsHandler interface {
 	HandleRevertEvents(revertBlock data.RevertBlock)
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
 	HandleTxsEvents(blockTxs data.BlockTxs)
+	HandleScrsEvents(blockScrs data.BlockScrs)
 	IsInterfaceNil() bool
 }
 

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -11,6 +11,7 @@ type EventsHandler interface {
 	HandlePushEvents(events data.BlockEvents)
 	HandleRevertEvents(revertBlock data.RevertBlock)
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
+	HandleTxsEvents(blockTxs data.BlockTxs)
 	IsInterfaceNil() bool
 }
 

--- a/facade/notifierFacade.go
+++ b/facade/notifierFacade.go
@@ -62,6 +62,11 @@ func (nf *notifierFacade) HandleFinalizedEvents(events data.FinalizedBlock) {
 	nf.eventsHandler.HandleFinalizedEvents(events)
 }
 
+// HandleTxsEvents
+func (nf *notifierFacade) HandleTxsEvents(events data.BlockTxs) {
+	nf.eventsHandler.HandleTxsEvents(events)
+}
+
 // ServeHTTP will handle a websocket request
 func (nf *notifierFacade) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	nf.wsHandler.ServeHTTP(w, r)

--- a/facade/notifierFacade.go
+++ b/facade/notifierFacade.go
@@ -60,6 +60,12 @@ func (nf *notifierFacade) HandlePushEvents(allEvents data.SaveBlockData) {
 		Txs:  allEvents.Txs,
 	}
 	nf.eventsHandler.HandleTxsEvents(txs)
+
+	scrs := data.BlockScrs{
+		Hash: allEvents.Hash,
+		Scrs: allEvents.Scrs,
+	}
+	nf.eventsHandler.HandleScrsEvents(scrs)
 }
 
 // HandleRevertEvents will handle revents events received from observer

--- a/facade/notifierFacade.go
+++ b/facade/notifierFacade.go
@@ -60,13 +60,13 @@ func (nf *notifierFacade) HandlePushEvents(allEvents data.SaveBlockData) {
 		Hash: allEvents.Hash,
 		Txs:  allEvents.Txs,
 	}
-	nf.eventsHandler.HandleTxsEvents(txs)
+	nf.eventsHandler.HandleBlockTxs(txs)
 
 	scrs := data.BlockScrs{
 		Hash: allEvents.Hash,
 		Scrs: allEvents.Scrs,
 	}
-	nf.eventsHandler.HandleScrsEvents(scrs)
+	nf.eventsHandler.HandleBlockScrs(scrs)
 }
 
 // HandleRevertEvents will handle revents events received from observer

--- a/facade/notifierFacade.go
+++ b/facade/notifierFacade.go
@@ -48,8 +48,18 @@ func checkArgs(args ArgsNotifierFacade) error {
 }
 
 // HandlePushEvents will handle push events received from observer
-func (nf *notifierFacade) HandlePushEvents(events data.BlockEvents) {
-	nf.eventsHandler.HandlePushEvents(events)
+func (nf *notifierFacade) HandlePushEvents(allEvents data.SaveBlockData) {
+	pushEvents := data.BlockEvents{
+		Hash:   allEvents.Hash,
+		Events: allEvents.LogEvents,
+	}
+	nf.eventsHandler.HandlePushEvents(pushEvents)
+
+	txs := data.BlockTxs{
+		Hash: allEvents.Hash,
+		Txs:  allEvents.Txs,
+	}
+	nf.eventsHandler.HandleTxsEvents(txs)
 }
 
 // HandleRevertEvents will handle revents events received from observer
@@ -60,11 +70,6 @@ func (nf *notifierFacade) HandleRevertEvents(events data.RevertBlock) {
 // HandleFinalizedEvents will handle finalized events received from observer
 func (nf *notifierFacade) HandleFinalizedEvents(events data.FinalizedBlock) {
 	nf.eventsHandler.HandleFinalizedEvents(events)
-}
-
-// HandleTxsEvents
-func (nf *notifierFacade) HandleTxsEvents(events data.BlockTxs) {
-	nf.eventsHandler.HandleTxsEvents(events)
 }
 
 // ServeHTTP will handle a websocket request

--- a/facade/notifierFacade.go
+++ b/facade/notifierFacade.go
@@ -48,6 +48,7 @@ func checkArgs(args ArgsNotifierFacade) error {
 }
 
 // HandlePushEvents will handle push events received from observer
+// It splits block data and handles log, txs and srcs events separately
 func (nf *notifierFacade) HandlePushEvents(allEvents data.SaveBlockData) {
 	pushEvents := data.BlockEvents{
 		Hash:   allEvents.Hash,

--- a/facade/notifierFacade_test.go
+++ b/facade/notifierFacade_test.go
@@ -109,11 +109,11 @@ func TestHandlePushEvents(t *testing.T) {
 			pushWasCalled = true
 			assert.Equal(t, expLogEvents, events)
 		},
-		HandleTxsEventsCalled: func(blockTxs data.BlockTxs) {
+		HandleBlockTxsCalled: func(blockTxs data.BlockTxs) {
 			txsWasCalled = true
 			assert.Equal(t, expTxsData, blockTxs)
 		},
-		HandleScrsEventsCalled: func(blockScrs data.BlockScrs) {
+		HandleBlockScrsCalled: func(blockScrs data.BlockScrs) {
 			scrsWasCalled = true
 			assert.Equal(t, expScrsData, blockScrs)
 		},
@@ -162,10 +162,10 @@ func TestHandleFinalizedEvents(t *testing.T) {
 		Hash: "hash1",
 	}
 
-	pushWasCalled := false
+	finalizedWasCalled := false
 	args.EventsHandler = &mocks.EventsHandlerStub{
 		HandleFinalizedEventsCalled: func(finalizedBlock data.FinalizedBlock) {
-			pushWasCalled = true
+			finalizedWasCalled = true
 			assert.Equal(t, finalizedData, finalizedBlock)
 		},
 	}
@@ -174,7 +174,7 @@ func TestHandleFinalizedEvents(t *testing.T) {
 
 	facade.HandleFinalizedEvents(finalizedData)
 
-	assert.True(t, pushWasCalled)
+	assert.True(t, finalizedWasCalled)
 }
 
 func TestServerHTTP(t *testing.T) {

--- a/facade/notifierFacade_test.go
+++ b/facade/notifierFacade_test.go
@@ -138,10 +138,10 @@ func TestHandleRevertEvents(t *testing.T) {
 		Nonce: 1,
 	}
 
-	pushWasCalled := false
+	revertWasCalled := false
 	args.EventsHandler = &mocks.EventsHandlerStub{
 		HandleRevertEventsCalled: func(revertBlock data.RevertBlock) {
-			pushWasCalled = true
+			revertWasCalled = true
 			assert.Equal(t, revertData, revertBlock)
 		},
 	}
@@ -150,7 +150,7 @@ func TestHandleRevertEvents(t *testing.T) {
 
 	facade.HandleRevertEvents(revertData)
 
-	assert.True(t, pushWasCalled)
+	assert.True(t, revertWasCalled)
 }
 
 func TestHandleFinalizedEvents(t *testing.T) {

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -8,7 +8,7 @@ import (
 
 // FacadeHandler defines facade behaviour
 type FacadeHandler interface {
-	HandlePushEvents(events data.BlockEvents)
+	HandlePushEvents(events data.SaveBlockData)
 	HandleRevertEvents(revertBlock data.RevertBlock)
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
 	GetConnectorUserAndPass() (string, string)

--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -42,7 +42,7 @@ func TestNotifierWithRabbitMQ(t *testing.T) {
 	mutResponses.Unlock()
 
 	assert.Equal(t, 5, len(notifier.RedisClient.GetEntries()))
-	assert.Equal(t, 3, len(notifier.RabbitMQClient.GetEntries()))
+	assert.Equal(t, 5, len(notifier.RabbitMQClient.GetEntries()))
 }
 
 func pushEventsRequest(webServer *integrationTests.TestWebServer, mutResponses *sync.Mutex, responses map[int]int) {

--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -41,14 +41,14 @@ func TestNotifierWithRabbitMQ(t *testing.T) {
 	assert.Equal(t, 5, responses[http.StatusOK])
 	mutResponses.Unlock()
 
-	assert.Equal(t, 3, len(notifier.RedisClient.GetEntries()))
+	assert.Equal(t, 5, len(notifier.RedisClient.GetEntries()))
 	assert.Equal(t, 3, len(notifier.RabbitMQClient.GetEntries()))
 }
 
 func pushEventsRequest(webServer *integrationTests.TestWebServer, mutResponses *sync.Mutex, responses map[int]int) {
-	blockEvents := &data.BlockEvents{
+	blockEvents := &data.SaveBlockData{
 		Hash: "hash1",
-		Events: []data.Event{
+		LogEvents: []data.Event{
 			{
 				Address: "addr1",
 			},

--- a/integrationTests/testNotifierProxy.go
+++ b/integrationTests/testNotifierProxy.go
@@ -146,6 +146,8 @@ func GetDefaultConfigs() *config.GeneralConfig {
 			EventsExchange:          "all_events",
 			RevertEventsExchange:    "revert_events",
 			FinalizedEventsExchange: "finalized_events",
+			TxsEventsExchange:       "txs",
+			ScrsEventsExchange:      "scrs",
 		},
 		Flags: &config.FlagsConfig{
 			LogLevel:          "*:INFO",

--- a/integrationTests/testNotifierProxy.go
+++ b/integrationTests/testNotifierProxy.go
@@ -146,8 +146,8 @@ func GetDefaultConfigs() *config.GeneralConfig {
 			EventsExchange:          "all_events",
 			RevertEventsExchange:    "revert_events",
 			FinalizedEventsExchange: "finalized_events",
-			TxsEventsExchange:       "txs",
-			ScrsEventsExchange:      "scrs",
+			BlockTxsExchange:        "txs",
+			BlockScrsExchange:       "scrs",
 		},
 		Flags: &config.FlagsConfig{
 			LogLevel:          "*:INFO",

--- a/integrationTests/testWSServer.go
+++ b/integrationTests/testWSServer.go
@@ -126,6 +126,50 @@ func (ws *wsClient) ReceiveFinalized() (*data.FinalizedBlock, error) {
 	return &event, nil
 }
 
+// ReceiveTxs will try to receive block txs event
+func (ws *wsClient) ReceiveTxs() (*data.BlockTxs, error) {
+	m, err := ws.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+
+	var reply data.WSEvent
+	err = json.Unmarshal(m, &reply)
+	if err != nil {
+		return nil, err
+	}
+
+	var event data.BlockTxs
+	err = json.Unmarshal(reply.Data, &event)
+	if err != nil {
+		return nil, err
+	}
+
+	return &event, nil
+}
+
+// ReceiveScrs will try to receive block txs event
+func (ws *wsClient) ReceiveScrs() (*data.BlockScrs, error) {
+	m, err := ws.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+
+	var reply data.WSEvent
+	err = json.Unmarshal(m, &reply)
+	if err != nil {
+		return nil, err
+	}
+
+	var event data.BlockScrs
+	err = json.Unmarshal(reply.Data, &event)
+	if err != nil {
+		return nil, err
+	}
+
+	return &event, nil
+}
+
 // Close will close connection
 func (ws *wsClient) Close() {
 	ws.httpServer.Close()

--- a/integrationTests/testWebServer.go
+++ b/integrationTests/testWebServer.go
@@ -109,17 +109,6 @@ func (w *TestWebServer) FinalizedEventsRequest(events *data.FinalizedBlock) *htt
 	return resp
 }
 
-// TxsEventsRequest will send a http request for finalized event
-func (w *TestWebServer) TxsEventsRequest(events *data.FinalizedBlock) *httptest.ResponseRecorder {
-	jsonBytes, _ := json.Marshal(events)
-
-	req, _ := http.NewRequest("POST", "/events/finalized", bytes.NewBuffer(jsonBytes))
-	req.Header.Set("Content-Type", "application/json")
-
-	resp := w.DoRequest(req)
-	return resp
-}
-
 func loadResponse(t *testing.T, rsp io.Reader, destination interface{}) {
 	jsonParser := json.NewDecoder(rsp)
 	err := jsonParser.Decode(destination)

--- a/integrationTests/testWebServer.go
+++ b/integrationTests/testWebServer.go
@@ -109,6 +109,17 @@ func (w *TestWebServer) FinalizedEventsRequest(events *data.FinalizedBlock) *htt
 	return resp
 }
 
+// TxsEventsRequest will send a http request for finalized event
+func (w *TestWebServer) TxsEventsRequest(events *data.FinalizedBlock) *httptest.ResponseRecorder {
+	jsonBytes, _ := json.Marshal(events)
+
+	req, _ := http.NewRequest("POST", "/events/finalized", bytes.NewBuffer(jsonBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := w.DoRequest(req)
+	return resp
+}
+
 func loadResponse(t *testing.T, rsp io.Reader, destination interface{}) {
 	jsonParser := json.NewDecoder(rsp)
 	err := jsonParser.Decode(destination)

--- a/integrationTests/testWebServer.go
+++ b/integrationTests/testWebServer.go
@@ -77,7 +77,7 @@ func (w *TestWebServer) createGroups() map[string]shared.GroupHandler {
 }
 
 // PushEventsRequest will send a http request for push events
-func (w *TestWebServer) PushEventsRequest(events *data.BlockEvents) *httptest.ResponseRecorder {
+func (w *TestWebServer) PushEventsRequest(events *data.SaveBlockData) *httptest.ResponseRecorder {
 	jsonBytes, _ := json.Marshal(events)
 
 	req, _ := http.NewRequest("POST", "/events/push", bytes.NewBuffer(jsonBytes))

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -42,9 +42,9 @@ func TestNotifierWithWebsockets_PushEvents(t *testing.T) {
 			Address: "addr1",
 		},
 	}
-	blockEvents := &data.BlockEvents{
-		Hash:   "hash1",
-		Events: events,
+	blockEvents := &data.SaveBlockData{
+		Hash:      "hash1",
+		LogEvents: events,
 	}
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
@@ -204,9 +204,9 @@ func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 			Address: "addr1",
 		},
 	}
-	blockEvents := &data.BlockEvents{
-		Hash:   "hash1",
-		Events: events,
+	blockEvents := &data.SaveBlockData{
+		Hash:      "hash1",
+		LogEvents: events,
 	}
 
 	wg := &sync.WaitGroup{}
@@ -251,5 +251,5 @@ func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 
 	wg.Wait()
 
-	assert.Equal(t, 3, len(notifier.RedisClient.GetEntries()))
+	assert.Equal(t, 5, len(notifier.RedisClient.GetEntries()))
 }

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/notifier-go/common"
 	"github.com/ElrondNetwork/notifier-go/data"
 	"github.com/ElrondNetwork/notifier-go/integrationTests"
@@ -159,6 +161,120 @@ func TestNotifierWithWebsockets_FinalizedEvents(t *testing.T) {
 	wg.Wait()
 }
 
+func TestNotifierWithWebsockets_TxsEvents(t *testing.T) {
+	cfg := integrationTests.GetDefaultConfigs()
+	notifier, err := integrationTests.NewTestNotifierWithWS(cfg)
+	require.Nil(t, err)
+
+	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.MessageQueueAPIType)
+
+	notifier.Publisher.Run()
+	defer notifier.Publisher.Close()
+
+	ws, err := integrationTests.NewWSClient(notifier.WSHandler)
+	require.Nil(t, err)
+	defer ws.Close()
+
+	subscribeEvent := &data.SubscribeEvent{
+		SubscriptionEntries: []data.SubscriptionEntry{
+			{
+				EventType: "txs_events",
+			},
+		},
+	}
+
+	ws.SendSubscribeMessage(subscribeEvent)
+
+	blockHash := "hash1"
+	txs := map[string]transaction.Transaction{
+		"txhash1": {
+			Nonce: 1,
+		},
+	}
+	blockEvents := &data.SaveBlockData{
+		Hash: blockHash,
+		Txs:  txs,
+	}
+	expBlockTxs := &data.BlockTxs{
+		Hash: blockHash,
+		Txs:  txs,
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		reply, err := ws.ReceiveTxs()
+		require.Nil(t, err)
+
+		assert.Equal(t, expBlockTxs, reply)
+		wg.Done()
+	}()
+
+	time.Sleep(time.Second)
+
+	webServer.PushEventsRequest(blockEvents)
+
+	wg.Wait()
+}
+
+func TestNotifierWithWebsockets_ScrsEvents(t *testing.T) {
+	cfg := integrationTests.GetDefaultConfigs()
+	notifier, err := integrationTests.NewTestNotifierWithWS(cfg)
+	require.Nil(t, err)
+
+	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.MessageQueueAPIType)
+
+	notifier.Publisher.Run()
+	defer notifier.Publisher.Close()
+
+	ws, err := integrationTests.NewWSClient(notifier.WSHandler)
+	require.Nil(t, err)
+	defer ws.Close()
+
+	subscribeEvent := &data.SubscribeEvent{
+		SubscriptionEntries: []data.SubscriptionEntry{
+			{
+				EventType: "scrs_events",
+			},
+		},
+	}
+
+	ws.SendSubscribeMessage(subscribeEvent)
+
+	blockHash := "hash1"
+	scrs := map[string]smartContractResult.SmartContractResult{
+		"hash2": {
+			Nonce: 2,
+		},
+	}
+	blockEvents := &data.SaveBlockData{
+		Hash: blockHash,
+		Scrs: scrs,
+	}
+	expBlockScrs := &data.BlockScrs{
+		Hash: blockHash,
+		Scrs: scrs,
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		reply, err := ws.ReceiveScrs()
+		require.Nil(t, err)
+
+		assert.Equal(t, expBlockScrs, reply)
+		wg.Done()
+	}()
+
+	time.Sleep(time.Second)
+
+	webServer.PushEventsRequest(blockEvents)
+
+	wg.Wait()
+}
+
 func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 	cfg := integrationTests.GetDefaultConfigs()
 	cfg.ConnectorApi.CheckDuplicates = true
@@ -185,6 +301,12 @@ func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 			{
 				EventType: "finalized_events",
 			},
+			{
+				EventType: "txs_events",
+			},
+			{
+				EventType: "scrs_events",
+			},
 		},
 	}
 
@@ -204,16 +326,39 @@ func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 			Address: "addr1",
 		},
 	}
+
+	txs := map[string]transaction.Transaction{
+		"txhash1": {
+			Nonce: 1,
+		},
+	}
+	scrs := map[string]smartContractResult.SmartContractResult{
+		"txhash2": {
+			Nonce: 2,
+		},
+	}
+	blockHash := "hash1"
+	blockTxs := &data.BlockTxs{
+		Hash: blockHash,
+		Txs:  txs,
+	}
+	blockScrs := &data.BlockScrs{
+		Hash: blockHash,
+		Scrs: scrs,
+	}
 	blockEvents := &data.SaveBlockData{
-		Hash:      "hash1",
+		Hash:      blockHash,
 		LogEvents: events,
+		Txs:       txs,
+		Scrs:      scrs,
 	}
 
+	numEvents := 5
 	wg := &sync.WaitGroup{}
-	wg.Add(3)
+	wg.Add(numEvents)
 
 	go func(wg *sync.WaitGroup) {
-		for i := 0; i < 3; i++ {
+		for i := 0; i < numEvents; i++ {
 			m, err := ws.ReadMessage()
 			require.Nil(t, err)
 
@@ -236,6 +381,16 @@ func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 				var event *data.FinalizedBlock
 				_ = json.Unmarshal(reply.Data, &event)
 				assert.Equal(t, finalizedBlock, event)
+				wg.Done()
+			case common.BlockTxsEvents:
+				var event *data.BlockTxs
+				_ = json.Unmarshal(reply.Data, &event)
+				assert.Equal(t, blockTxs, event)
+				wg.Done()
+			case common.BlockScrsEvents:
+				var event *data.BlockScrs
+				_ = json.Unmarshal(reply.Data, &event)
+				assert.Equal(t, blockScrs, event)
 				wg.Done()
 			default:
 				t.Errorf("invalid message type")

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -55,7 +55,7 @@ func TestNotifierWithWebsockets_PushEvents(t *testing.T) {
 		reply, err := ws.ReceiveEvents()
 		require.Nil(t, err)
 
-		assert.Equal(t, events, reply)
+		require.Equal(t, events, reply)
 		wg.Done()
 	}()
 
@@ -103,7 +103,7 @@ func TestNotifierWithWebsockets_RevertEvents(t *testing.T) {
 		reply, err := ws.ReceiveRevertBlock()
 		require.Nil(t, err)
 
-		assert.Equal(t, blockEvents, reply)
+		require.Equal(t, blockEvents, reply)
 		wg.Done()
 	}()
 
@@ -150,7 +150,7 @@ func TestNotifierWithWebsockets_FinalizedEvents(t *testing.T) {
 		reply, err := ws.ReceiveFinalized()
 		require.Nil(t, err)
 
-		assert.Equal(t, blockEvents, reply)
+		require.Equal(t, blockEvents, reply)
 		wg.Done()
 	}()
 
@@ -207,7 +207,7 @@ func TestNotifierWithWebsockets_TxsEvents(t *testing.T) {
 		reply, err := ws.ReceiveTxs()
 		require.Nil(t, err)
 
-		assert.Equal(t, expBlockTxs, reply)
+		require.Equal(t, expBlockTxs, reply)
 		wg.Done()
 	}()
 
@@ -264,7 +264,7 @@ func TestNotifierWithWebsockets_ScrsEvents(t *testing.T) {
 		reply, err := ws.ReceiveScrs()
 		require.Nil(t, err)
 
-		assert.Equal(t, expBlockScrs, reply)
+		require.Equal(t, expBlockScrs, reply)
 		wg.Done()
 	}()
 
@@ -406,5 +406,5 @@ func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 
 	wg.Wait()
 
-	assert.Equal(t, 5, len(notifier.RedisClient.GetEntries()))
+	assert.Equal(t, numEvents, len(notifier.RedisClient.GetEntries()))
 }

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -32,7 +32,7 @@ func TestNotifierWithWebsockets_PushEvents(t *testing.T) {
 	subscribeEvent := &data.SubscribeEvent{
 		SubscriptionEntries: []data.SubscriptionEntry{
 			{
-				EventType: "all_events",
+				EventType: common.PushBlockEvents,
 			},
 		},
 	}
@@ -84,7 +84,7 @@ func TestNotifierWithWebsockets_RevertEvents(t *testing.T) {
 	subscribeEvent := &data.SubscribeEvent{
 		SubscriptionEntries: []data.SubscriptionEntry{
 			{
-				EventType: "revert_events",
+				EventType: common.RevertBlockEvents,
 			},
 		},
 	}
@@ -132,7 +132,7 @@ func TestNotifierWithWebsockets_FinalizedEvents(t *testing.T) {
 	subscribeEvent := &data.SubscribeEvent{
 		SubscriptionEntries: []data.SubscriptionEntry{
 			{
-				EventType: "finalized_events",
+				EventType: common.FinalizedBlockEvents,
 			},
 		},
 	}
@@ -178,7 +178,7 @@ func TestNotifierWithWebsockets_TxsEvents(t *testing.T) {
 	subscribeEvent := &data.SubscribeEvent{
 		SubscriptionEntries: []data.SubscriptionEntry{
 			{
-				EventType: "txs_events",
+				EventType: common.BlockTxs,
 			},
 		},
 	}
@@ -235,7 +235,7 @@ func TestNotifierWithWebsockets_ScrsEvents(t *testing.T) {
 	subscribeEvent := &data.SubscribeEvent{
 		SubscriptionEntries: []data.SubscriptionEntry{
 			{
-				EventType: "scrs_events",
+				EventType: common.BlockScrs,
 			},
 		},
 	}
@@ -293,19 +293,19 @@ func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 	subscribeEvent := &data.SubscribeEvent{
 		SubscriptionEntries: []data.SubscriptionEntry{
 			{
-				EventType: "all_events",
+				EventType: common.PushBlockEvents,
 			},
 			{
-				EventType: "revert_events",
+				EventType: common.RevertBlockEvents,
 			},
 			{
-				EventType: "finalized_events",
+				EventType: common.FinalizedBlockEvents,
 			},
 			{
-				EventType: "txs_events",
+				EventType: common.BlockTxs,
 			},
 			{
-				EventType: "scrs_events",
+				EventType: common.BlockScrs,
 			},
 		},
 	}
@@ -382,12 +382,12 @@ func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 				_ = json.Unmarshal(reply.Data, &event)
 				assert.Equal(t, finalizedBlock, event)
 				wg.Done()
-			case common.BlockTxsEvents:
+			case common.BlockTxs:
 				var event *data.BlockTxs
 				_ = json.Unmarshal(reply.Data, &event)
 				assert.Equal(t, blockTxs, event)
 				wg.Done()
-			case common.BlockScrsEvents:
+			case common.BlockScrs:
 				var event *data.BlockScrs
 				_ = json.Unmarshal(reply.Data, &event)
 				assert.Equal(t, blockScrs, event)

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -20,7 +20,7 @@ func TestNotifierWithWebsockets_PushEvents(t *testing.T) {
 	notifier, err := integrationTests.NewTestNotifierWithWS(cfg)
 	require.Nil(t, err)
 
-	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.MessageQueueAPIType)
+	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.WSAPIType)
 
 	notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
@@ -72,7 +72,7 @@ func TestNotifierWithWebsockets_RevertEvents(t *testing.T) {
 	notifier, err := integrationTests.NewTestNotifierWithWS(cfg)
 	require.Nil(t, err)
 
-	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.MessageQueueAPIType)
+	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.WSAPIType)
 
 	notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
@@ -120,7 +120,7 @@ func TestNotifierWithWebsockets_FinalizedEvents(t *testing.T) {
 	notifier, err := integrationTests.NewTestNotifierWithWS(cfg)
 	require.Nil(t, err)
 
-	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.MessageQueueAPIType)
+	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.WSAPIType)
 
 	notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
@@ -166,7 +166,7 @@ func TestNotifierWithWebsockets_TxsEvents(t *testing.T) {
 	notifier, err := integrationTests.NewTestNotifierWithWS(cfg)
 	require.Nil(t, err)
 
-	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.MessageQueueAPIType)
+	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.WSAPIType)
 
 	notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
@@ -223,7 +223,7 @@ func TestNotifierWithWebsockets_ScrsEvents(t *testing.T) {
 	notifier, err := integrationTests.NewTestNotifierWithWS(cfg)
 	require.Nil(t, err)
 
-	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.MessageQueueAPIType)
+	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.WSAPIType)
 
 	notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
@@ -281,7 +281,7 @@ func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 	notifier, err := integrationTests.NewTestNotifierWithWS(cfg)
 	require.Nil(t, err)
 
-	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.MessageQueueAPIType)
+	webServer := integrationTests.NewTestWebServer(notifier.Facade, common.WSAPIType)
 
 	notifier.Publisher.Run()
 	defer notifier.Publisher.Close()

--- a/mocks/dispatcherMock.go
+++ b/mocks/dispatcherMock.go
@@ -40,6 +40,14 @@ func (d *DispatcherMock) RevertEvent(event data.RevertBlock) {
 func (d *DispatcherMock) FinalizedEvent(event data.FinalizedBlock) {
 }
 
+// TxsEvent -
+func (d *DispatcherMock) TxsEvent(event data.BlockTxs) {
+}
+
+// ScrsEvent -
+func (d *DispatcherMock) ScrsEvent(event data.BlockScrs) {
+}
+
 // Subscribe -
 func (d *DispatcherMock) Subscribe(event data.SubscribeEvent) {
 	d.hub.Subscribe(event)

--- a/mocks/dispatcherStub.go
+++ b/mocks/dispatcherStub.go
@@ -11,6 +11,8 @@ type DispatcherStub struct {
 	PushEventsCalled     func(events []data.Event)
 	RevertEventCalled    func(event data.RevertBlock)
 	FinalizedEventCalled func(event data.FinalizedBlock)
+	TxsEventCalled       func(event data.BlockTxs)
+	ScrsEventCalled      func(event data.BlockScrs)
 }
 
 // GetID -
@@ -40,5 +42,19 @@ func (d *DispatcherStub) RevertEvent(event data.RevertBlock) {
 func (d *DispatcherStub) FinalizedEvent(event data.FinalizedBlock) {
 	if d.FinalizedEventCalled != nil {
 		d.FinalizedEventCalled(event)
+	}
+}
+
+// TxsEvent -
+func (d *DispatcherStub) TxsEvent(event data.BlockTxs) {
+	if d.TxsEventCalled != nil {
+		d.TxsEventCalled(event)
+	}
+}
+
+// ScrsEvent -
+func (d *DispatcherStub) ScrsEvent(event data.BlockScrs) {
+	if d.ScrsEventCalled != nil {
+		d.ScrsEventCalled(event)
 	}
 }

--- a/mocks/eventsHandlerStub.go
+++ b/mocks/eventsHandlerStub.go
@@ -7,8 +7,8 @@ type EventsHandlerStub struct {
 	HandlePushEventsCalled      func(events data.BlockEvents)
 	HandleRevertEventsCalled    func(revertBlock data.RevertBlock)
 	HandleFinalizedEventsCalled func(finalizedBlock data.FinalizedBlock)
-	HandleTxsEventsCalled       func(blockTxs data.BlockTxs)
-	HandleScrsEventsCalled      func(blockScrs data.BlockScrs)
+	HandleBlockTxsCalled        func(blockTxs data.BlockTxs)
+	HandleBlockScrsCalled       func(blockScrs data.BlockScrs)
 }
 
 // HandlePushEvents -
@@ -32,17 +32,17 @@ func (e *EventsHandlerStub) HandleFinalizedEvents(finalizedBlock data.FinalizedB
 	}
 }
 
-// HandleTxsEvents -
-func (e *EventsHandlerStub) HandleTxsEvents(blockTxs data.BlockTxs) {
-	if e.HandleTxsEventsCalled != nil {
-		e.HandleTxsEventsCalled(blockTxs)
+// HandleBlockTxs -
+func (e *EventsHandlerStub) HandleBlockTxs(blockTxs data.BlockTxs) {
+	if e.HandleBlockTxsCalled != nil {
+		e.HandleBlockTxsCalled(blockTxs)
 	}
 }
 
-// HandleScrsEvents -
-func (e *EventsHandlerStub) HandleScrsEvents(blockScrs data.BlockScrs) {
-	if e.HandleScrsEventsCalled != nil {
-		e.HandleScrsEventsCalled(blockScrs)
+// HandleBlockScrs -
+func (e *EventsHandlerStub) HandleBlockScrs(blockScrs data.BlockScrs) {
+	if e.HandleBlockScrsCalled != nil {
+		e.HandleBlockScrsCalled(blockScrs)
 	}
 }
 

--- a/mocks/eventsHandlerStub.go
+++ b/mocks/eventsHandlerStub.go
@@ -7,6 +7,8 @@ type EventsHandlerStub struct {
 	HandlePushEventsCalled      func(events data.BlockEvents)
 	HandleRevertEventsCalled    func(revertBlock data.RevertBlock)
 	HandleFinalizedEventsCalled func(finalizedBlock data.FinalizedBlock)
+	HandleTxsEventsCalled       func(blockTxs data.BlockTxs)
+	HandleScrsEventsCalled      func(blockScrs data.BlockScrs)
 }
 
 // HandlePushEvents -
@@ -27,6 +29,20 @@ func (e *EventsHandlerStub) HandleRevertEvents(revertBlock data.RevertBlock) {
 func (e *EventsHandlerStub) HandleFinalizedEvents(finalizedBlock data.FinalizedBlock) {
 	if e.HandleFinalizedEventsCalled != nil {
 		e.HandleFinalizedEventsCalled(finalizedBlock)
+	}
+}
+
+// HandleTxsEvents -
+func (e *EventsHandlerStub) HandleTxsEvents(blockTxs data.BlockTxs) {
+	if e.HandleTxsEventsCalled != nil {
+		e.HandleTxsEventsCalled(blockTxs)
+	}
+}
+
+// HandleScrsEvents -
+func (e *EventsHandlerStub) HandleScrsEvents(blockScrs data.BlockScrs) {
+	if e.HandleScrsEventsCalled != nil {
+		e.HandleScrsEventsCalled(blockScrs)
 	}
 }
 

--- a/mocks/facadeStub.go
+++ b/mocks/facadeStub.go
@@ -8,7 +8,7 @@ import (
 
 // FacadeStub implements FacadeHandler interface
 type FacadeStub struct {
-	HandlePushEventsCalled        func(events data.BlockEvents)
+	HandlePushEventsCalled        func(events data.SaveBlockData)
 	HandleRevertEventsCalled      func(events data.RevertBlock)
 	HandleFinalizedEventsCalled   func(events data.FinalizedBlock)
 	ServeCalled                   func(w http.ResponseWriter, r *http.Request)
@@ -16,7 +16,7 @@ type FacadeStub struct {
 }
 
 // HandlePushEvents -
-func (fs *FacadeStub) HandlePushEvents(events data.BlockEvents) {
+func (fs *FacadeStub) HandlePushEvents(events data.SaveBlockData) {
 	if fs.HandlePushEventsCalled != nil {
 		fs.HandlePushEventsCalled(events)
 	}

--- a/mocks/hubStub.go
+++ b/mocks/hubStub.go
@@ -11,6 +11,8 @@ type HubStub struct {
 	BroadcastCalled          func(events data.BlockEvents)
 	BroadcastRevertCalled    func(event data.RevertBlock)
 	BroadcastFinalizedCalled func(event data.FinalizedBlock)
+	BroadcastTxsCalled       func(event data.BlockTxs)
+	BroadcastScrsCalled      func(event data.BlockScrs)
 	RegisterEventCalled      func(event dispatcher.EventDispatcher)
 	UnregisterEventCalled    func(event dispatcher.EventDispatcher)
 	SubscribeCalled          func(event data.SubscribeEvent)
@@ -42,6 +44,20 @@ func (h *HubStub) BroadcastRevert(event data.RevertBlock) {
 func (h *HubStub) BroadcastFinalized(event data.FinalizedBlock) {
 	if h.BroadcastFinalizedCalled != nil {
 		h.BroadcastFinalizedCalled(event)
+	}
+}
+
+// BroadcastTxs -
+func (h *HubStub) BroadcastTxs(event data.BlockTxs) {
+	if h.BroadcastTxsCalled != nil {
+		h.BroadcastTxsCalled(event)
+	}
+}
+
+// BroadcastScrs -
+func (h *HubStub) BroadcastScrs(event data.BlockScrs) {
+	if h.BroadcastScrsCalled != nil {
+		h.BroadcastScrsCalled(event)
 	}
 }
 

--- a/mocks/publisherStub.go
+++ b/mocks/publisherStub.go
@@ -8,6 +8,8 @@ type PublisherStub struct {
 	BroadcastCalled          func(events data.BlockEvents)
 	BroadcastRevertCalled    func(event data.RevertBlock)
 	BroadcastFinalizedCalled func(event data.FinalizedBlock)
+	BroadcastTxsCalled       func(event data.BlockTxs)
+	BroadcastScrsCalled      func(event data.BlockScrs)
 }
 
 // Run -
@@ -35,6 +37,20 @@ func (ps *PublisherStub) BroadcastRevert(event data.RevertBlock) {
 func (ps *PublisherStub) BroadcastFinalized(event data.FinalizedBlock) {
 	if ps.BroadcastFinalizedCalled != nil {
 		ps.BroadcastFinalizedCalled(event)
+	}
+}
+
+// BroadcastTxs -
+func (ps *PublisherStub) BroadcastTxs(event data.BlockTxs) {
+	if ps.BroadcastTxsCalled != nil {
+		ps.BroadcastTxsCalled(event)
+	}
+}
+
+// BroadcastScrs -
+func (ps *PublisherStub) BroadcastScrs(event data.BlockScrs) {
+	if ps.BroadcastScrsCalled != nil {
+		ps.BroadcastScrsCalled(event)
 	}
 }
 

--- a/process/eventsHandler.go
+++ b/process/eventsHandler.go
@@ -150,8 +150,8 @@ func (eh *eventsHandler) HandleFinalizedEvents(finalizedBlock data.FinalizedBloc
 	eh.publisher.BroadcastFinalized(finalizedBlock)
 }
 
-// HandleTxsEvents will handle txs events received from observer
-func (eh *eventsHandler) HandleTxsEvents(blockTxs data.BlockTxs) {
+// HandleBlockTxs will handle txs events received from observer
+func (eh *eventsHandler) HandleBlockTxs(blockTxs data.BlockTxs) {
 	if blockTxs.Hash == "" {
 		log.Warn("received empty txs block hash",
 			"will process", false,
@@ -180,8 +180,8 @@ func (eh *eventsHandler) HandleTxsEvents(blockTxs data.BlockTxs) {
 	eh.publisher.BroadcastTxs(blockTxs)
 }
 
-// HandleScrsEvents will handle scrs events received from observer
-func (eh *eventsHandler) HandleScrsEvents(blockScrs data.BlockScrs) {
+// HandleBlockScrs will handle scrs events received from observer
+func (eh *eventsHandler) HandleBlockScrs(blockScrs data.BlockScrs) {
 	if blockScrs.Hash == "" {
 		log.Warn("received empty scrs block hash",
 			"will process", false,

--- a/process/eventsHandler.go
+++ b/process/eventsHandler.go
@@ -73,19 +73,20 @@ func (eh *eventsHandler) HandlePushEvents(events data.BlockEvents) {
 		shouldProcessEvents = eh.tryCheckProcessedWithRetry(events.Hash)
 	}
 
-	if events.Events != nil && shouldProcessEvents {
-		log.Info("received events for block",
+	if events.Events == nil || !shouldProcessEvents {
+		log.Info("received duplicated events for block",
 			"block hash", events.Hash,
-			"will process", shouldProcessEvents,
+			"processed", false,
 		)
-		eh.publisher.Broadcast(events)
 		return
 	}
 
-	log.Info("received duplicated events for block",
+	log.Info("received events for block",
 		"block hash", events.Hash,
-		"processed", false,
+		"will process", shouldProcessEvents,
 	)
+
+	eh.publisher.Broadcast(events)
 }
 
 // HandleRevertEvents will handle revents events received from observer
@@ -103,19 +104,20 @@ func (eh *eventsHandler) HandleRevertEvents(revertBlock data.RevertBlock) {
 		shouldProcessRevert = eh.tryCheckProcessedWithRetry(revertKey)
 	}
 
-	if shouldProcessRevert {
-		log.Info("received revert event for block",
+	if !shouldProcessRevert {
+		log.Info("received duplicated revert event for block",
 			"block hash", revertBlock.Hash,
-			"will process", shouldProcessRevert,
+			"processed", false,
 		)
-		eh.publisher.BroadcastRevert(revertBlock)
 		return
 	}
 
-	log.Info("received duplicated revert event for block",
+	log.Info("received revert event for block",
 		"block hash", revertBlock.Hash,
-		"processed", false,
+		"will process", shouldProcessRevert,
 	)
+
+	eh.publisher.BroadcastRevert(revertBlock)
 }
 
 // HandleFinalizedEvents will handle finalized events received from observer
@@ -132,19 +134,20 @@ func (eh *eventsHandler) HandleFinalizedEvents(finalizedBlock data.FinalizedBloc
 		shouldProcessFinalized = eh.tryCheckProcessedWithRetry(finalizedKey)
 	}
 
-	if shouldProcessFinalized {
-		log.Info("received finalized events for block",
+	if !shouldProcessFinalized {
+		log.Info("received duplicated finalized event for block",
 			"block hash", finalizedBlock.Hash,
-			"will process", shouldProcessFinalized,
+			"processed", false,
 		)
-		eh.publisher.BroadcastFinalized(finalizedBlock)
 		return
 	}
 
-	log.Info("received duplicated finalized event for block",
+	log.Info("received finalized events for block",
 		"block hash", finalizedBlock.Hash,
-		"processed", false,
+		"will process", shouldProcessFinalized,
 	)
+
+	eh.publisher.BroadcastFinalized(finalizedBlock)
 }
 
 // HandleTxsEvents will handle txs events received from observer
@@ -161,19 +164,20 @@ func (eh *eventsHandler) HandleTxsEvents(blockTxs data.BlockTxs) {
 		shouldProcessTxs = eh.tryCheckProcessedWithRetry(txsKey)
 	}
 
-	if shouldProcessTxs {
-		log.Info("received txs events for block",
+	if !shouldProcessTxs {
+		log.Info("received duplicated txs event for block",
 			"block hash", blockTxs.Hash,
-			"will process", shouldProcessTxs,
+			"processed", false,
 		)
-		eh.publisher.BroadcastTxs(blockTxs)
 		return
 	}
 
-	log.Info("received duplicated txs event for block",
+	log.Info("received txs events for block",
 		"block hash", blockTxs.Hash,
-		"processed", false,
+		"will process", shouldProcessTxs,
 	)
+
+	eh.publisher.BroadcastTxs(blockTxs)
 }
 
 // HandleScrsEvents will handle scrs events received from observer
@@ -190,19 +194,20 @@ func (eh *eventsHandler) HandleScrsEvents(blockScrs data.BlockScrs) {
 		shouldProcessScrs = eh.tryCheckProcessedWithRetry(scrsKey)
 	}
 
-	if shouldProcessScrs {
-		log.Info("received scrs events for block",
+	if !shouldProcessScrs {
+		log.Info("received duplicated scrs event for block",
 			"block hash", blockScrs.Hash,
-			"will process", shouldProcessScrs,
+			"processed", false,
 		)
-		eh.publisher.BroadcastScrs(blockScrs)
 		return
 	}
 
-	log.Info("received duplicated scrs event for block",
+	log.Info("received scrs events for block",
 		"block hash", blockScrs.Hash,
-		"processed", false,
+		"will process", shouldProcessScrs,
 	)
+
+	eh.publisher.BroadcastScrs(blockScrs)
 }
 
 func (eh *eventsHandler) tryCheckProcessedWithRetry(blockHash string) bool {

--- a/process/eventsHandler_test.go
+++ b/process/eventsHandler_test.go
@@ -275,7 +275,7 @@ func TestHandleTxsEvents(t *testing.T) {
 			},
 		}
 
-		eventsHandler.HandleTxsEvents(events)
+		eventsHandler.HandleBlockTxs(events)
 		require.True(t, wasCalled)
 	})
 
@@ -308,7 +308,7 @@ func TestHandleTxsEvents(t *testing.T) {
 			},
 		}
 
-		eventsHandler.HandleTxsEvents(events)
+		eventsHandler.HandleBlockTxs(events)
 		require.False(t, wasCalled)
 	})
 }
@@ -339,7 +339,7 @@ func TestHandleScrsEvents(t *testing.T) {
 			},
 		}
 
-		eventsHandler.HandleScrsEvents(events)
+		eventsHandler.HandleBlockScrs(events)
 		require.True(t, wasCalled)
 	})
 
@@ -372,7 +372,7 @@ func TestHandleScrsEvents(t *testing.T) {
 			},
 		}
 
-		eventsHandler.HandleScrsEvents(events)
+		eventsHandler.HandleBlockScrs(events)
 		require.False(t, wasCalled)
 	})
 }

--- a/process/eventsHandler_test.go
+++ b/process/eventsHandler_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ElrondNetwork/notifier-go/data"
 	"github.com/ElrondNetwork/notifier-go/mocks"
 	"github.com/ElrondNetwork/notifier-go/process"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,7 +83,7 @@ func TestHandlePushEvents(t *testing.T) {
 		}
 
 		eventsHandler.HandlePushEvents(events)
-		assert.False(t, wasCalled)
+		require.False(t, wasCalled)
 	})
 
 	t.Run("broadcast event was called", func(t *testing.T) {
@@ -107,7 +106,7 @@ func TestHandlePushEvents(t *testing.T) {
 		}
 
 		eventsHandler.HandlePushEvents(events)
-		assert.True(t, wasCalled)
+		require.True(t, wasCalled)
 	})
 
 	t.Run("check duplicates enabled, should not process event", func(t *testing.T) {
@@ -136,7 +135,7 @@ func TestHandlePushEvents(t *testing.T) {
 		}
 
 		eventsHandler.HandlePushEvents(events)
-		assert.False(t, wasCalled)
+		require.False(t, wasCalled)
 	})
 }
 
@@ -163,7 +162,7 @@ func TestHandleRevertEvents(t *testing.T) {
 		}
 
 		eventsHandler.HandleRevertEvents(events)
-		assert.True(t, wasCalled)
+		require.True(t, wasCalled)
 	})
 
 	t.Run("check duplicates enabled, should not process event", func(t *testing.T) {
@@ -192,7 +191,7 @@ func TestHandleRevertEvents(t *testing.T) {
 		}
 
 		eventsHandler.HandleRevertEvents(events)
-		assert.False(t, wasCalled)
+		require.False(t, wasCalled)
 	})
 }
 
@@ -218,7 +217,7 @@ func TestHandleFinalizedEvents(t *testing.T) {
 		}
 
 		eventsHandler.HandleFinalizedEvents(events)
-		assert.True(t, wasCalled)
+		require.True(t, wasCalled)
 	})
 
 	t.Run("check duplicates enabled, should not process event", func(t *testing.T) {
@@ -246,7 +245,7 @@ func TestHandleFinalizedEvents(t *testing.T) {
 		}
 
 		eventsHandler.HandleFinalizedEvents(events)
-		assert.False(t, wasCalled)
+		require.False(t, wasCalled)
 	})
 }
 
@@ -277,7 +276,7 @@ func TestHandleTxsEvents(t *testing.T) {
 		}
 
 		eventsHandler.HandleTxsEvents(events)
-		assert.True(t, wasCalled)
+		require.True(t, wasCalled)
 	})
 
 	t.Run("check duplicates enabled, should not process event", func(t *testing.T) {
@@ -310,7 +309,7 @@ func TestHandleTxsEvents(t *testing.T) {
 		}
 
 		eventsHandler.HandleTxsEvents(events)
-		assert.False(t, wasCalled)
+		require.False(t, wasCalled)
 	})
 }
 
@@ -341,7 +340,7 @@ func TestHandleScrsEvents(t *testing.T) {
 		}
 
 		eventsHandler.HandleScrsEvents(events)
-		assert.True(t, wasCalled)
+		require.True(t, wasCalled)
 	})
 
 	t.Run("check duplicates enabled, should not process event", func(t *testing.T) {
@@ -374,7 +373,7 @@ func TestHandleScrsEvents(t *testing.T) {
 		}
 
 		eventsHandler.HandleScrsEvents(events)
-		assert.False(t, wasCalled)
+		require.False(t, wasCalled)
 	})
 }
 
@@ -398,7 +397,7 @@ func TestTryCheckProcessedWithRetry(t *testing.T) {
 		require.Nil(t, err)
 
 		ok := eventsHandler.TryCheckProcessedWithRetry(hash)
-		assert.False(t, ok)
+		require.False(t, ok)
 	})
 
 	t.Run("event is already processed", func(t *testing.T) {
@@ -416,7 +415,7 @@ func TestTryCheckProcessedWithRetry(t *testing.T) {
 		require.Nil(t, err)
 
 		ok := eventsHandler.TryCheckProcessedWithRetry(hash)
-		assert.True(t, ok)
+		require.True(t, ok)
 	})
 
 	t.Run("locker service is failing on first try, has no connection, works on second try", func(t *testing.T) {
@@ -447,6 +446,6 @@ func TestTryCheckProcessedWithRetry(t *testing.T) {
 		require.Nil(t, err)
 
 		ok := eventsHandler.TryCheckProcessedWithRetry(hash)
-		assert.True(t, ok)
+		require.True(t, ok)
 	})
 }

--- a/process/interface.go
+++ b/process/interface.go
@@ -21,6 +21,7 @@ type Publisher interface {
 	BroadcastRevert(event data.RevertBlock)
 	BroadcastFinalized(event data.FinalizedBlock)
 	BroadcastTxs(event data.BlockTxs)
+	BroadcastScrs(event data.BlockScrs)
 	IsInterfaceNil() bool
 }
 
@@ -30,5 +31,6 @@ type EventsHandler interface {
 	HandleRevertEvents(revertBlock data.RevertBlock)
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
 	HandleTxsEvents(blockTxs data.BlockTxs)
+	HandleScrsEvents(blockScrs data.BlockScrs)
 	IsInterfaceNil() bool
 }

--- a/process/interface.go
+++ b/process/interface.go
@@ -20,6 +20,7 @@ type Publisher interface {
 	Broadcast(events data.BlockEvents)
 	BroadcastRevert(event data.RevertBlock)
 	BroadcastFinalized(event data.FinalizedBlock)
+	BroadcastTxs(event data.BlockTxs)
 	IsInterfaceNil() bool
 }
 
@@ -28,5 +29,6 @@ type EventsHandler interface {
 	HandlePushEvents(events data.BlockEvents)
 	HandleRevertEvents(revertBlock data.RevertBlock)
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
+	HandleTxsEvents(blockTxs data.BlockTxs)
 	IsInterfaceNil() bool
 }

--- a/process/interface.go
+++ b/process/interface.go
@@ -30,7 +30,7 @@ type EventsHandler interface {
 	HandlePushEvents(events data.BlockEvents)
 	HandleRevertEvents(revertBlock data.RevertBlock)
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
-	HandleTxsEvents(blockTxs data.BlockTxs)
-	HandleScrsEvents(blockScrs data.BlockScrs)
+	HandleBlockTxs(blockTxs data.BlockTxs)
+	HandleBlockScrs(blockScrs data.BlockScrs)
 	IsInterfaceNil() bool
 }

--- a/rabbitmq/errors.go
+++ b/rabbitmq/errors.go
@@ -4,3 +4,6 @@ import "errors"
 
 // ErrNilRabbitMqClient signals that a nil rabbitmq client has been provided
 var ErrNilRabbitMqClient = errors.New("nil rabbitmq client")
+
+// ErrInvalidRabbitMqExchangeName signals that an empty rabbitmq exchange name has been provided
+var ErrInvalidRabbitMqExchangeName = errors.New("invalid rabbitmq exchange name")

--- a/rabbitmq/interface.go
+++ b/rabbitmq/interface.go
@@ -24,6 +24,7 @@ type PublisherService interface {
 	BroadcastRevert(event data.RevertBlock)
 	BroadcastFinalized(event data.FinalizedBlock)
 	BroadcastTxs(event data.BlockTxs)
+	BroadcastScrs(event data.BlockScrs)
 	Close() error
 	IsInterfaceNil() bool
 }

--- a/rabbitmq/interface.go
+++ b/rabbitmq/interface.go
@@ -23,6 +23,7 @@ type PublisherService interface {
 	Broadcast(events data.BlockEvents)
 	BroadcastRevert(event data.RevertBlock)
 	BroadcastFinalized(event data.FinalizedBlock)
+	BroadcastTxs(event data.BlockTxs)
 	Close() error
 	IsInterfaceNil() bool
 }

--- a/rabbitmq/publisher.go
+++ b/rabbitmq/publisher.go
@@ -102,7 +102,7 @@ func (rp *rabbitMqPublisher) run(ctx context.Context) {
 	}
 }
 
-// Broadcast will handle the block events pushed by producers, and sends them to rabbitMQ channel
+// Broadcast will handle the block events pushed by producers and sends them to rabbitMQ channel
 func (rp *rabbitMqPublisher) Broadcast(events data.BlockEvents) {
 	select {
 	case rp.broadcast <- events:
@@ -110,7 +110,7 @@ func (rp *rabbitMqPublisher) Broadcast(events data.BlockEvents) {
 	}
 }
 
-// BroadcastRevert will handle the revert event pushed by producers, and sends them to rabbitMQ channel
+// BroadcastRevert will handle the revert event pushed by producers and sends them to rabbitMQ channel
 func (rp *rabbitMqPublisher) BroadcastRevert(events data.RevertBlock) {
 	select {
 	case rp.broadcastRevert <- events:
@@ -118,7 +118,7 @@ func (rp *rabbitMqPublisher) BroadcastRevert(events data.RevertBlock) {
 	}
 }
 
-// BroadcastFinalized will handle the finalized event pushed by producers, and sends them to rabbitMQ channel
+// BroadcastFinalized will handle the finalized event pushed by producers and sends them to rabbitMQ channel
 func (rp *rabbitMqPublisher) BroadcastFinalized(events data.FinalizedBlock) {
 	select {
 	case rp.broadcastFinalized <- events:
@@ -126,7 +126,7 @@ func (rp *rabbitMqPublisher) BroadcastFinalized(events data.FinalizedBlock) {
 	}
 }
 
-// BroadcastTxs will handle the txs event pushed by producers, and sends them to rabbitMQ channel
+// BroadcastTxs will handle the txs event pushed by producers and sends them to rabbitMQ channel
 func (rp *rabbitMqPublisher) BroadcastTxs(events data.BlockTxs) {
 	select {
 	case rp.broadcastTxs <- events:
@@ -134,7 +134,7 @@ func (rp *rabbitMqPublisher) BroadcastTxs(events data.BlockTxs) {
 	}
 }
 
-// BroadcastScrs will handle the scrs event pushed by producers, and sends them to rabbitMQ channel
+// BroadcastScrs will handle the scrs event pushed by producers and sends them to rabbitMQ channel
 func (rp *rabbitMqPublisher) BroadcastScrs(events data.BlockScrs) {
 	select {
 	case rp.broadcastScrs <- events:

--- a/rabbitmq/publisher.go
+++ b/rabbitmq/publisher.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
@@ -59,6 +60,21 @@ func NewRabbitMqPublisher(args ArgsRabbitMqPublisher) (*rabbitMqPublisher, error
 func checkArgs(args ArgsRabbitMqPublisher) error {
 	if check.IfNil(args.Client) {
 		return ErrNilRabbitMqClient
+	}
+	if args.Config.EventsExchange == "" {
+		return fmt.Errorf("empty events exchange name: %w", ErrInvalidRabbitMqExchangeName)
+	}
+	if args.Config.RevertEventsExchange == "" {
+		return fmt.Errorf("empty revert exchange name: %w", ErrInvalidRabbitMqExchangeName)
+	}
+	if args.Config.FinalizedEventsExchange == "" {
+		return fmt.Errorf("empty finalized exchange name: %w", ErrInvalidRabbitMqExchangeName)
+	}
+	if args.Config.TxsEventsExchange == "" {
+		return fmt.Errorf("empty txs exchange name: %w", ErrInvalidRabbitMqExchangeName)
+	}
+	if args.Config.ScrsEventsExchange == "" {
+		return fmt.Errorf("empty scrs exchange name: %w", ErrInvalidRabbitMqExchangeName)
 	}
 
 	return nil
@@ -143,77 +159,67 @@ func (rp *rabbitMqPublisher) BroadcastScrs(events data.BlockScrs) {
 }
 
 func (rp *rabbitMqPublisher) publishToExchanges(events data.BlockEvents) {
-	if rp.cfg.EventsExchange != "" {
-		eventsBytes, err := json.Marshal(events)
-		if err != nil {
-			log.Error("could not marshal events", "err", err.Error())
-			return
-		}
+	eventsBytes, err := json.Marshal(events)
+	if err != nil {
+		log.Error("could not marshal events", "err", err.Error())
+		return
+	}
 
-		err = rp.publishFanout(rp.cfg.EventsExchange, eventsBytes)
-		if err != nil {
-			log.Error("failed to publish events to rabbitMQ", "err", err.Error())
-		}
+	err = rp.publishFanout(rp.cfg.EventsExchange, eventsBytes)
+	if err != nil {
+		log.Error("failed to publish events to rabbitMQ", "err", err.Error())
 	}
 }
 
 func (rp *rabbitMqPublisher) publishRevertToExchange(revertBlock data.RevertBlock) {
-	if rp.cfg.RevertEventsExchange != "" {
-		revertBlockBytes, err := json.Marshal(revertBlock)
-		if err != nil {
-			log.Error("could not marshal revert event", "err", err.Error())
-			return
-		}
+	revertBlockBytes, err := json.Marshal(revertBlock)
+	if err != nil {
+		log.Error("could not marshal revert event", "err", err.Error())
+		return
+	}
 
-		err = rp.publishFanout(rp.cfg.RevertEventsExchange, revertBlockBytes)
-		if err != nil {
-			log.Error("failed to publish revert event to rabbitMQ", "err", err.Error())
-		}
+	err = rp.publishFanout(rp.cfg.RevertEventsExchange, revertBlockBytes)
+	if err != nil {
+		log.Error("failed to publish revert event to rabbitMQ", "err", err.Error())
 	}
 }
 
 func (rp *rabbitMqPublisher) publishFinalizedToExchange(finalizedBlock data.FinalizedBlock) {
-	if rp.cfg.FinalizedEventsExchange != "" {
-		finalizedBlockBytes, err := json.Marshal(finalizedBlock)
-		if err != nil {
-			log.Error("could not marshal finalized event", "err", err.Error())
-			return
-		}
+	finalizedBlockBytes, err := json.Marshal(finalizedBlock)
+	if err != nil {
+		log.Error("could not marshal finalized event", "err", err.Error())
+		return
+	}
 
-		err = rp.publishFanout(rp.cfg.FinalizedEventsExchange, finalizedBlockBytes)
-		if err != nil {
-			log.Error("failed to publish finalized event to rabbitMQ", "err", err.Error())
-		}
+	err = rp.publishFanout(rp.cfg.FinalizedEventsExchange, finalizedBlockBytes)
+	if err != nil {
+		log.Error("failed to publish finalized event to rabbitMQ", "err", err.Error())
 	}
 }
 
 func (rp *rabbitMqPublisher) publishTxsToExchange(blockTxs data.BlockTxs) {
-	if rp.cfg.TxsEventsExchange != "" {
-		txsBlockBytes, err := json.Marshal(blockTxs)
-		if err != nil {
-			log.Error("could not marshal block txs event", "err", err.Error())
-			return
-		}
+	txsBlockBytes, err := json.Marshal(blockTxs)
+	if err != nil {
+		log.Error("could not marshal block txs event", "err", err.Error())
+		return
+	}
 
-		err = rp.publishFanout(rp.cfg.TxsEventsExchange, txsBlockBytes)
-		if err != nil {
-			log.Error("failed to publish block txs event to rabbitMQ", "err", err.Error())
-		}
+	err = rp.publishFanout(rp.cfg.TxsEventsExchange, txsBlockBytes)
+	if err != nil {
+		log.Error("failed to publish block txs event to rabbitMQ", "err", err.Error())
 	}
 }
 
 func (rp *rabbitMqPublisher) publishScrsToExchange(blockScrs data.BlockScrs) {
-	if rp.cfg.ScrsEventsExchange != "" {
-		scrsBlockBytes, err := json.Marshal(blockScrs)
-		if err != nil {
-			log.Error("could not marshal block scrs event", "err", err.Error())
-			return
-		}
+	scrsBlockBytes, err := json.Marshal(blockScrs)
+	if err != nil {
+		log.Error("could not marshal block scrs event", "err", err.Error())
+		return
+	}
 
-		err = rp.publishFanout(rp.cfg.ScrsEventsExchange, scrsBlockBytes)
-		if err != nil {
-			log.Error("failed to publish block scrs event to rabbitMQ", "err", err.Error())
-		}
+	err = rp.publishFanout(rp.cfg.ScrsEventsExchange, scrsBlockBytes)
+	if err != nil {
+		log.Error("failed to publish block scrs event to rabbitMQ", "err", err.Error())
 	}
 }
 

--- a/rabbitmq/publisher.go
+++ b/rabbitmq/publisher.go
@@ -70,11 +70,11 @@ func checkArgs(args ArgsRabbitMqPublisher) error {
 	if args.Config.FinalizedEventsExchange == "" {
 		return fmt.Errorf("empty finalized exchange name: %w", ErrInvalidRabbitMqExchangeName)
 	}
-	if args.Config.TxsEventsExchange == "" {
-		return fmt.Errorf("empty txs exchange name: %w", ErrInvalidRabbitMqExchangeName)
+	if args.Config.BlockTxsExchange == "" {
+		return fmt.Errorf("empty block txs exchange name: %w", ErrInvalidRabbitMqExchangeName)
 	}
-	if args.Config.ScrsEventsExchange == "" {
-		return fmt.Errorf("empty scrs exchange name: %w", ErrInvalidRabbitMqExchangeName)
+	if args.Config.BlockScrsExchange == "" {
+		return fmt.Errorf("empty block scrs exchange name: %w", ErrInvalidRabbitMqExchangeName)
 	}
 
 	return nil
@@ -204,7 +204,7 @@ func (rp *rabbitMqPublisher) publishTxsToExchange(blockTxs data.BlockTxs) {
 		return
 	}
 
-	err = rp.publishFanout(rp.cfg.TxsEventsExchange, txsBlockBytes)
+	err = rp.publishFanout(rp.cfg.BlockTxsExchange, txsBlockBytes)
 	if err != nil {
 		log.Error("failed to publish block txs event to rabbitMQ", "err", err.Error())
 	}
@@ -217,7 +217,7 @@ func (rp *rabbitMqPublisher) publishScrsToExchange(blockScrs data.BlockScrs) {
 		return
 	}
 
-	err = rp.publishFanout(rp.cfg.ScrsEventsExchange, scrsBlockBytes)
+	err = rp.publishFanout(rp.cfg.BlockScrsExchange, scrsBlockBytes)
 	if err != nil {
 		log.Error("failed to publish block scrs event to rabbitMQ", "err", err.Error())
 	}

--- a/rabbitmq/publisher_test.go
+++ b/rabbitmq/publisher_test.go
@@ -1,6 +1,7 @@
 package rabbitmq_test
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -40,6 +41,61 @@ func TestRabbitMqPublisher(t *testing.T) {
 		client, err := rabbitmq.NewRabbitMqPublisher(args)
 		require.True(t, check.IfNil(client))
 		require.Equal(t, rabbitmq.ErrNilRabbitMqClient, err)
+	})
+
+	t.Run("invalid events exchange name", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsRabbitMqPublisher()
+		args.Config.EventsExchange = ""
+
+		client, err := rabbitmq.NewRabbitMqPublisher(args)
+		require.True(t, check.IfNil(client))
+		require.True(t, errors.Is(err, rabbitmq.ErrInvalidRabbitMqExchangeName))
+	})
+
+	t.Run("invalid revert exchange name", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsRabbitMqPublisher()
+		args.Config.RevertEventsExchange = ""
+
+		client, err := rabbitmq.NewRabbitMqPublisher(args)
+		require.True(t, check.IfNil(client))
+		require.True(t, errors.Is(err, rabbitmq.ErrInvalidRabbitMqExchangeName))
+	})
+
+	t.Run("invalid finalized exchange name", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsRabbitMqPublisher()
+		args.Config.FinalizedEventsExchange = ""
+
+		client, err := rabbitmq.NewRabbitMqPublisher(args)
+		require.True(t, check.IfNil(client))
+		require.True(t, errors.Is(err, rabbitmq.ErrInvalidRabbitMqExchangeName))
+	})
+
+	t.Run("invalid txs exchange name", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsRabbitMqPublisher()
+		args.Config.TxsEventsExchange = ""
+
+		client, err := rabbitmq.NewRabbitMqPublisher(args)
+		require.True(t, check.IfNil(client))
+		require.True(t, errors.Is(err, rabbitmq.ErrInvalidRabbitMqExchangeName))
+	})
+
+	t.Run("invalid scrs exchange name", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsRabbitMqPublisher()
+		args.Config.ScrsEventsExchange = ""
+
+		client, err := rabbitmq.NewRabbitMqPublisher(args)
+		require.True(t, check.IfNil(client))
+		require.True(t, errors.Is(err, rabbitmq.ErrInvalidRabbitMqExchangeName))
 	})
 
 	t.Run("should work", func(t *testing.T) {

--- a/rabbitmq/publisher_test.go
+++ b/rabbitmq/publisher_test.go
@@ -23,8 +23,8 @@ func createMockArgsRabbitMqPublisher() rabbitmq.ArgsRabbitMqPublisher {
 			EventsExchange:          "allevents",
 			RevertEventsExchange:    "revert",
 			FinalizedEventsExchange: "finalized",
-			TxsEventsExchange:       "txs",
-			ScrsEventsExchange:      "scrs",
+			BlockTxsExchange:        "txs",
+			BlockScrsExchange:       "scrs",
 		},
 	}
 }
@@ -80,7 +80,7 @@ func TestRabbitMqPublisher(t *testing.T) {
 		t.Parallel()
 
 		args := createMockArgsRabbitMqPublisher()
-		args.Config.TxsEventsExchange = ""
+		args.Config.BlockTxsExchange = ""
 
 		client, err := rabbitmq.NewRabbitMqPublisher(args)
 		require.True(t, check.IfNil(client))
@@ -91,7 +91,7 @@ func TestRabbitMqPublisher(t *testing.T) {
 		t.Parallel()
 
 		args := createMockArgsRabbitMqPublisher()
-		args.Config.ScrsEventsExchange = ""
+		args.Config.BlockScrsExchange = ""
 
 		client, err := rabbitmq.NewRabbitMqPublisher(args)
 		require.True(t, check.IfNil(client))


### PR DESCRIPTION
Event notifier driver has been updated to send txs and scrs together with log events.
Handle Txs and Scrs from TransactionPool:
- rabbitmq: separate exchanges
- websockets: different event types per scrs and events