### PR TITLE
Change logs for empty events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,21 @@ compose-stop:
 
 compose-rm:
 	docker-compose down
+
+
+# #########################
+# Test Data
+# #########################
+
+test_data_file = ./examples/requests.json
+
+# it can be "push", "revert", "finalized"
+event_type = "push"
+
+request-test:
+	curl \
+		-X POST \
+		-H "Content-Type: application/json" \
+		-u aaaa:aaa \
+		-d @${test_data_file} \
+		http://localhost:5000/events/${event_type}

--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/notifier-go/common"
 	"github.com/ElrondNetwork/notifier-go/data"
 	"github.com/ElrondNetwork/notifier-go/integrationTests"
@@ -48,6 +50,16 @@ func TestNotifierWithRabbitMQ(t *testing.T) {
 func pushEventsRequest(webServer *integrationTests.TestWebServer, mutResponses *sync.Mutex, responses map[int]int) {
 	blockEvents := &data.SaveBlockData{
 		Hash: "hash1",
+		Txs: map[string]transaction.Transaction{
+			"txHash1": {
+				Nonce: 1,
+			},
+		},
+		Scrs: map[string]smartContractResult.SmartContractResult{
+			"scrHash1": {
+				Nonce: 2,
+			},
+		},
 		LogEvents: []data.Event{
 			{
 				Address: "addr1",

--- a/process/eventsHandler.go
+++ b/process/eventsHandler.go
@@ -73,7 +73,15 @@ func (eh *eventsHandler) HandlePushEvents(events data.BlockEvents) {
 		shouldProcessEvents = eh.tryCheckProcessedWithRetry(events.Hash)
 	}
 
-	if events.Events == nil || !shouldProcessEvents {
+	if events.Events == nil {
+		log.Info("received empty events for block",
+			"block hash", events.Hash,
+			"processed", false,
+		)
+		return
+	}
+
+	if !shouldProcessEvents {
 		log.Info("received duplicated events for block",
 			"block hash", events.Hash,
 			"processed", false,
@@ -172,6 +180,14 @@ func (eh *eventsHandler) HandleBlockTxs(blockTxs data.BlockTxs) {
 		return
 	}
 
+	if len(blockTxs.Txs) == 0 {
+		log.Info("received empty txs event for block",
+			"block hash", blockTxs.Hash,
+			"processed", false,
+		)
+		return
+	}
+
 	log.Info("received txs events for block",
 		"block hash", blockTxs.Hash,
 		"will process", shouldProcessTxs,
@@ -196,6 +212,14 @@ func (eh *eventsHandler) HandleBlockScrs(blockScrs data.BlockScrs) {
 
 	if !shouldProcessScrs {
 		log.Info("received duplicated scrs event for block",
+			"block hash", blockScrs.Hash,
+			"processed", false,
+		)
+		return
+	}
+
+	if len(blockScrs.Scrs) == 0 {
+		log.Info("received empty scrs event for block",
 			"block hash", blockScrs.Hash,
 			"processed", false,
 		)


### PR DESCRIPTION
Handle txs and scrs similar to log events: if there are no txs or scrs, do not send event to rabbitmq
- better logging when receiving empty events