### PR TITLE
More detailed logging on publisher

### DIFF
--- a/process/eventsHandler.go
+++ b/process/eventsHandler.go
@@ -73,14 +73,6 @@ func (eh *eventsHandler) HandlePushEvents(events data.BlockEvents) {
 		shouldProcessEvents = eh.tryCheckProcessedWithRetry(events.Hash)
 	}
 
-	if events.Events == nil {
-		log.Info("received empty events for block",
-			"block hash", events.Hash,
-			"processed", false,
-		)
-		return
-	}
-
 	if !shouldProcessEvents {
 		log.Info("received duplicated events for block",
 			"block hash", events.Hash,
@@ -89,10 +81,17 @@ func (eh *eventsHandler) HandlePushEvents(events data.BlockEvents) {
 		return
 	}
 
-	log.Info("received events for block",
-		"block hash", events.Hash,
-		"will process", shouldProcessEvents,
-	)
+	if len(events.Events) == 0 {
+		log.Info("received empty events for block",
+			"block hash", events.Hash,
+			"will process", shouldProcessEvents,
+		)
+	} else {
+		log.Info("received events for block",
+			"block hash", events.Hash,
+			"will process", shouldProcessEvents,
+		)
+	}
 
 	eh.publisher.Broadcast(events)
 }
@@ -183,15 +182,14 @@ func (eh *eventsHandler) HandleBlockTxs(blockTxs data.BlockTxs) {
 	if len(blockTxs.Txs) == 0 {
 		log.Info("received empty txs event for block",
 			"block hash", blockTxs.Hash,
-			"processed", false,
+			"will process", shouldProcessTxs,
 		)
-		return
+	} else {
+		log.Info("received txs events for block",
+			"block hash", blockTxs.Hash,
+			"will process", shouldProcessTxs,
+		)
 	}
-
-	log.Info("received txs events for block",
-		"block hash", blockTxs.Hash,
-		"will process", shouldProcessTxs,
-	)
 
 	eh.publisher.BroadcastTxs(blockTxs)
 }
@@ -221,15 +219,14 @@ func (eh *eventsHandler) HandleBlockScrs(blockScrs data.BlockScrs) {
 	if len(blockScrs.Scrs) == 0 {
 		log.Info("received empty scrs event for block",
 			"block hash", blockScrs.Hash,
-			"processed", false,
+			"will process", shouldProcessScrs,
 		)
-		return
+	} else {
+		log.Info("received scrs events for block",
+			"block hash", blockScrs.Hash,
+			"will process", shouldProcessScrs,
+		)
 	}
-
-	log.Info("received scrs events for block",
-		"block hash", blockScrs.Hash,
-		"will process", shouldProcessScrs,
-	)
 
 	eh.publisher.BroadcastScrs(blockScrs)
 }

--- a/process/eventsHandler_test.go
+++ b/process/eventsHandler_test.go
@@ -63,29 +63,6 @@ func TestNewEventsHandler(t *testing.T) {
 func TestHandlePushEvents(t *testing.T) {
 	t.Parallel()
 
-	t.Run("broadcast event was NOT called", func(t *testing.T) {
-		t.Parallel()
-
-		wasCalled := false
-		args := createMockEventsHandlerArgs()
-		args.Publisher = &mocks.PublisherStub{
-			BroadcastCalled: func(events data.BlockEvents) {
-				wasCalled = true
-			},
-		}
-
-		eventsHandler, err := process.NewEventsHandler(args)
-		require.Nil(t, err)
-
-		events := data.BlockEvents{
-			Hash:   "hash1",
-			Events: nil,
-		}
-
-		eventsHandler.HandlePushEvents(events)
-		require.False(t, wasCalled)
-	})
-
 	t.Run("broadcast event was called", func(t *testing.T) {
 		t.Parallel()
 

--- a/rabbitmq/rabbitClient.go
+++ b/rabbitmq/rabbitClient.go
@@ -21,6 +21,7 @@ type rabbitMqClient struct {
 	connErrCh chan *amqp.Error
 	chanErr   chan *amqp.Error
 	ackCh     chan uint64
+	nackCh    chan uint64
 }
 
 // NewRabbitMQClient creates a new rabbitMQ client instance
@@ -63,6 +64,8 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 		case <-rc.ackCh:
 			log.Debug("Publish: published message ack")
 			return err
+		case <-rc.nackCh:
+			log.Debug("Publish: published message nack, will retry to publish message")
 		case err := <-rc.connErrCh:
 			if err != nil {
 				log.Error("rabbitMQ connection failure", "err", err.Error())
@@ -119,7 +122,7 @@ func (rc *rabbitMqClient) openChannel() error {
 
 	rc.chanErr = make(chan *amqp.Error)
 	rc.ch.NotifyClose(rc.chanErr)
-	rc.ackCh, _ = rc.ch.NotifyConfirm(make(chan uint64), make(chan uint64))
+	rc.ackCh, rc.nackCh = rc.ch.NotifyConfirm(make(chan uint64), make(chan uint64))
 
 	return rc.ch.Confirm(false)
 }

--- a/rabbitmq/rabbitClient.go
+++ b/rabbitmq/rabbitClient.go
@@ -65,7 +65,7 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 			log.Debug("Publish: published message ack")
 			return err
 		case <-rc.nackCh:
-			log.Debug("Publish: published message nack, will retry to publish message")
+			log.Debug("Publish: published message nack, will retry to publish message", "error", err)
 		case err := <-rc.connErrCh:
 			if err != nil {
 				log.Error("rabbitMQ connection failure", "err", err.Error())


### PR DESCRIPTION
- rabbitmq logging on not-acknowledge on publishing
- send block event to rabbitmq even if there are no logs, txs or scrs