### PR TITLE
Create rabbitmq exchange if not existing

### DIFF
--- a/cmd/notifier/config/config.toml
+++ b/cmd/notifier/config/config.toml
@@ -40,22 +40,27 @@
     # Note: not required for running in the notifier mode
     Url = "amqp://guest:guest@localhost:5672"
 
-    # The exchange name which holds all events
-    # Expected type: fanout
-    EventsExchange = "all_events"
+    # The exchange which holds all logs and events
+    [RabbitMQ.EventsExchange]
+        Name = "all_events"
+        Type = "fanout"
 
-    # The exchange name which holds revert events
-    # Expected type: fanout
-    RevertEventsExchange = "revert_events"
+    # The exchange which holds revert events
+    [RabbitMQ.RevertEventsExchange]
+        Name = "revert_events"
+        Type = "fanout"
 
-    # The exchange name which holds finalized block events
-    # Expected type: fanout
-    FinalizedEventsExchange = "finalized_events"
+    # The exchange which holds finalized block events
+    [RabbitMQ.FinalizedEventsExchange]
+        Name = "finalized_events"
+        Type = "fanout"
 
-    # The exchange name which holds block txs events
-    # Expected type: fanout
-    BlockTxsExchange = "block_txs"
+    # The exchange which holds block txs events
+    [RabbitMQ.BlockTxsExchange]
+        Name = "block_txs"
+        Type = "fanout"
 
-    # The exchange name which holds block scrs events
-    # Expected type: fanout
-    BlockScrsExchange = "block_scrs"
+    # The exchange which holds block scrs events
+    [RabbitMQ.BlockScrsExchange]
+        Name = "block_scrs"
+        Type = "fanout"

--- a/config/config.go
+++ b/config/config.go
@@ -31,11 +31,17 @@ type RedisConfig struct {
 // RabbitMQConfig maps the rabbitMQ configuration
 type RabbitMQConfig struct {
 	Url                     string
-	EventsExchange          string
-	RevertEventsExchange    string
-	FinalizedEventsExchange string
-	BlockTxsExchange        string
-	BlockScrsExchange       string
+	EventsExchange          RabbitMQExchangeConfig
+	RevertEventsExchange    RabbitMQExchangeConfig
+	FinalizedEventsExchange RabbitMQExchangeConfig
+	BlockTxsExchange        RabbitMQExchangeConfig
+	BlockScrsExchange       RabbitMQExchangeConfig
+}
+
+// RabbitMQExchangeConfig holds the configuration for a rabbitMQ exchange
+type RabbitMQExchangeConfig struct {
+	Name string
+	Type string
 }
 
 // FlagsConfig holds the values for CLI flags

--- a/integrationTests/testNotifierProxy.go
+++ b/integrationTests/testNotifierProxy.go
@@ -151,12 +151,27 @@ func GetDefaultConfigs() *config.GeneralConfig {
 			TTL:            30,
 		},
 		RabbitMQ: config.RabbitMQConfig{
-			Url:                     "amqp://guest:guest@localhost:5672",
-			EventsExchange:          "all_events",
-			RevertEventsExchange:    "revert_events",
-			FinalizedEventsExchange: "finalized_events",
-			BlockTxsExchange:        "txs",
-			BlockScrsExchange:       "scrs",
+			Url: "amqp://guest:guest@localhost:5672",
+			EventsExchange: config.RabbitMQExchangeConfig{
+				Name: "allevents",
+				Type: "fanout",
+			},
+			RevertEventsExchange: config.RabbitMQExchangeConfig{
+				Name: "revert",
+				Type: "fanout",
+			},
+			FinalizedEventsExchange: config.RabbitMQExchangeConfig{
+				Name: "finalized",
+				Type: "fanout",
+			},
+			BlockTxsExchange: config.RabbitMQExchangeConfig{
+				Name: "blocktxs",
+				Type: "fanout",
+			},
+			BlockScrsExchange: config.RabbitMQExchangeConfig{
+				Name: "blockscrs",
+				Type: "fanout",
+			},
 		},
 		Flags: &config.FlagsConfig{
 			LogLevel:          "*:INFO",

--- a/mocks/rabbitMqClientMock.go
+++ b/mocks/rabbitMqClientMock.go
@@ -29,6 +29,11 @@ func (rc *RabbitClientMock) Publish(exchange, key string, mandatory, immediate b
 	return nil
 }
 
+// ExchangeDeclare -
+func (rc *RabbitClientMock) ExchangeDeclare(name, kind string) error {
+	return nil
+}
+
 // ConnErrChan -
 func (rc *RabbitClientMock) ConnErrChan() chan *amqp.Error {
 	return make(chan *amqp.Error)

--- a/mocks/rabbitMqClientStub.go
+++ b/mocks/rabbitMqClientStub.go
@@ -4,18 +4,27 @@ import "github.com/streadway/amqp"
 
 // RabbitClientStub -
 type RabbitClientStub struct {
-	PublishCalled       func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
-	ConnErrChanCalled   func() chan *amqp.Error
-	CloseErrChanCalled  func() chan *amqp.Error
-	ReconnectCalled     func()
-	ReopenChannelCalled func()
-	CloseCalled         func()
+	PublishCalled         func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
+	ExchangeDeclareCalled func(name, kind string) error
+	ConnErrChanCalled     func() chan *amqp.Error
+	CloseErrChanCalled    func() chan *amqp.Error
+	ReconnectCalled       func()
+	ReopenChannelCalled   func()
+	CloseCalled           func()
 }
 
 // Publish -
 func (rc *RabbitClientStub) Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
 	if rc.PublishCalled != nil {
 		return rc.PublishCalled(exchange, key, mandatory, immediate, msg)
+	}
+	return nil
+}
+
+// ExchangeDeclare -
+func (rc *RabbitClientStub) ExchangeDeclare(name, kind string) error {
+	if rc.ExchangeDeclareCalled != nil {
+		return rc.ExchangeDeclareCalled(name, kind)
 	}
 	return nil
 }

--- a/rabbitmq/errors.go
+++ b/rabbitmq/errors.go
@@ -7,3 +7,6 @@ var ErrNilRabbitMqClient = errors.New("nil rabbitmq client")
 
 // ErrInvalidRabbitMqExchangeName signals that an empty rabbitmq exchange name has been provided
 var ErrInvalidRabbitMqExchangeName = errors.New("invalid rabbitmq exchange name")
+
+// ErrInvalidRabbitMqExchangeType signals that an empty rabbitmq exchange type has been provided
+var ErrInvalidRabbitMqExchangeType = errors.New("invalid rabbitmq exchange type")

--- a/rabbitmq/interface.go
+++ b/rabbitmq/interface.go
@@ -8,6 +8,7 @@ import (
 // RabbitMqClient defines the behaviour of a rabbitMq client
 type RabbitMqClient interface {
 	Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
+	ExchangeDeclare(name, kind string) error
 	ConnErrChan() chan *amqp.Error
 	CloseErrChan() chan *amqp.Error
 	Reconnect()

--- a/rabbitmq/publisher.go
+++ b/rabbitmq/publisher.go
@@ -55,7 +55,7 @@ func NewRabbitMqPublisher(args ArgsRabbitMqPublisher) (*rabbitMqPublisher, error
 		closeChan:          make(chan struct{}),
 	}
 
-	err = rp.checkAndCreateExchanges()
+	err = rp.createExchanges()
 	if err != nil {
 		return nil, err
 	}
@@ -68,28 +68,59 @@ func checkArgs(args ArgsRabbitMqPublisher) error {
 		return ErrNilRabbitMqClient
 	}
 
+	if args.Config.EventsExchange.Name == "" {
+		return ErrInvalidRabbitMqExchangeName
+	}
+	if args.Config.EventsExchange.Type == "" {
+		return ErrInvalidRabbitMqExchangeType
+	}
+	if args.Config.RevertEventsExchange.Name == "" {
+		return ErrInvalidRabbitMqExchangeName
+	}
+	if args.Config.RevertEventsExchange.Type == "" {
+		return ErrInvalidRabbitMqExchangeType
+	}
+	if args.Config.FinalizedEventsExchange.Name == "" {
+		return ErrInvalidRabbitMqExchangeName
+	}
+	if args.Config.FinalizedEventsExchange.Type == "" {
+		return ErrInvalidRabbitMqExchangeType
+	}
+	if args.Config.BlockTxsExchange.Name == "" {
+		return ErrInvalidRabbitMqExchangeName
+	}
+	if args.Config.BlockTxsExchange.Type == "" {
+		return ErrInvalidRabbitMqExchangeType
+	}
+	if args.Config.BlockScrsExchange.Name == "" {
+		return ErrInvalidRabbitMqExchangeName
+	}
+	if args.Config.BlockScrsExchange.Type == "" {
+		return ErrInvalidRabbitMqExchangeType
+	}
+
 	return nil
 }
 
 // checkAndCreateExchanges creates exchanges if they are not existing already
-func (rp *rabbitMqPublisher) checkAndCreateExchanges() error {
-	err := rp.checkAndCreateExchange(rp.cfg.EventsExchange)
+func (rp *rabbitMqPublisher) createExchanges() error {
+	err := rp.createExchange(rp.cfg.EventsExchange)
 	if err != nil {
 		return err
 	}
-	err = rp.checkAndCreateExchange(rp.cfg.RevertEventsExchange)
+	err = rp.createExchange(rp.cfg.RevertEventsExchange)
 	if err != nil {
 		return err
 	}
-	err = rp.checkAndCreateExchange(rp.cfg.FinalizedEventsExchange)
+	err = rp.createExchange(rp.cfg.FinalizedEventsExchange)
 	if err != nil {
 		return err
 	}
-	err = rp.checkAndCreateExchange(rp.cfg.BlockTxsExchange)
+	err = rp.createExchange(rp.cfg.BlockTxsExchange)
 	if err != nil {
 		return err
 	}
-	err = rp.checkAndCreateExchange(rp.cfg.BlockScrsExchange)
+	err = rp.createExchange(rp.cfg.BlockScrsExchange)
 	if err != nil {
 		return err
 	}
@@ -97,14 +128,7 @@ func (rp *rabbitMqPublisher) checkAndCreateExchanges() error {
 	return nil
 }
 
-func (rp *rabbitMqPublisher) checkAndCreateExchange(conf config.RabbitMQExchangeConfig) error {
-	if conf.Name == "" {
-		return ErrInvalidRabbitMqExchangeName
-	}
-	if conf.Type == "" {
-		return ErrInvalidRabbitMqExchangeType
-	}
-
+func (rp *rabbitMqPublisher) createExchange(conf config.RabbitMQExchangeConfig) error {
 	err := rp.client.ExchangeDeclare(conf.Name, conf.Type)
 	if err != nil {
 		return err

--- a/rabbitmq/rabbitClient.go
+++ b/rabbitmq/rabbitClient.go
@@ -9,6 +9,12 @@ import (
 
 const (
 	reconnectRetryMs = 500
+
+	// ExchangeDeclare constants
+	isDurable  = true
+	autoDelete = false
+	isInternal = false
+	noWait     = false
 )
 
 type rabbitMqClient struct {
@@ -42,13 +48,13 @@ func NewRabbitMQClient(url string) (*rabbitMqClient, error) {
 // ExchangeDeclare will declare an exchange
 func (rc *rabbitMqClient) ExchangeDeclare(name, kind string) error {
 	return rc.ch.ExchangeDeclare(
-		name,  // name
-		kind,  // type
-		true,  // durable
-		false, // auto-deleted
-		false, // internal
-		false, // no-wait
-		nil,   // arguments
+		name,
+		kind,
+		isDurable,
+		autoDelete,
+		isInternal,
+		noWait,
+		nil,
 	)
 }
 

--- a/rabbitmq/rabbitClient.go
+++ b/rabbitmq/rabbitClient.go
@@ -39,6 +39,19 @@ func NewRabbitMQClient(url string) (*rabbitMqClient, error) {
 	return rc, nil
 }
 
+// ExchangeDeclare will check and declare an exchange if it's not existing already
+func (rc *rabbitMqClient) ExchangeDeclare(name, kind string) error {
+	return rc.ch.ExchangeDeclare(
+		name,  // name
+		kind,  // type
+		true,  // durable
+		false, // auto-deleted
+		false, // internal
+		false, // no-wait
+		nil,   // arguments
+	)
+}
+
 // Publish will publich an item on the rabbitMq channel
 func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
 	rc.pubMut.Lock()


### PR DESCRIPTION
- when starting the rabbit publisher service, verify if the rabbtitMQ exchanges from config are already created, and if not create them